### PR TITLE
[FIX] sale_coupon_advanced: order_count

### DIFF
--- a/sale_coupon_advanced/i18n/fr.po
+++ b/sale_coupon_advanced/i18n/fr.po
@@ -31,7 +31,7 @@ msgid "Apply only on the first order of each client matching the conditions"
 msgstr "Appliquer uniquement sur la première commande de chaque client correspondant aux conditions"
 
 #. module: sale_coupon_advanced
-#: model:ir.model.fields,field_description:sale_coupon_advanced.field_sale_coupon_program__first_n_customer_orders
+#: model:ir.model.fields,field_description:sale_coupon_advanced.field_sale_coupon_program__next_n_customer_orders
 msgid "Apply only on the next "
 msgstr ""
 
@@ -44,7 +44,7 @@ msgstr "Le coupon ne peut être utilisé que pour la première commande!"
 #. module: sale_coupon_advanced
 #: code:addons/sale_coupon_advanced/models/sale_coupon_program.py:0
 #, python-format
-msgid "Coupon can be used only for the first {} sale order!"
+msgid "Coupon can be used only for the first {} times!"
 msgstr ""
 
 #. module: sale_coupon_advanced
@@ -70,7 +70,7 @@ msgid "If checked, the reward product will be added if not ordered."
 msgstr "Si sélectionné, le produit sera ajouté s'il n'a pas été commandé"
 
 #. module: sale_coupon_advanced
-#: model:ir.model.fields,help:sale_coupon_advanced.field_sale_coupon_program__first_n_customer_orders
+#: model:ir.model.fields,help:sale_coupon_advanced.field_sale_coupon_program__next_n_customer_orders
 msgid ""
 "Maximum number of sales orders of the customer in which reward          can "
 "be provided"

--- a/sale_coupon_advanced/models/sale_coupon_program.py
+++ b/sale_coupon_advanced/models/sale_coupon_program.py
@@ -15,7 +15,7 @@ class SaleCouponProgram(models.Model):
         help="Apply only on the first order of each client matching the conditions",
     )
 
-    first_n_customer_orders = fields.Integer(
+    next_n_customer_orders = fields.Integer(
         help="Maximum number of sales orders of the customer in which reward \
          can be provided",
         string="Apply only on the next ",
@@ -28,18 +28,16 @@ class SaleCouponProgram(models.Model):
     )
 
     def _check_promo_code(self, order, coupon_code):
-
         order_count = self._get_order_count(order)
         if self.first_order_only and order_count:
             return {"error": _("Coupon can be used only for the first sale order!")}
-        max_order_number = self.first_n_customer_orders
+        max_order_number = self.next_n_customer_orders
         if max_order_number and order_count >= max_order_number:
             return {
-                "error": _(
-                    "Coupon can be used only for the first {} sale order!"
-                ).format(max_order_number)
+                "error": _("Coupon can be used only for the first {} times!").format(
+                    max_order_number
+                )
             }
-
         # Do not return product unordered error message if
         # `is_reward_product_forced` is selected
         message = _(
@@ -53,12 +51,15 @@ class SaleCouponProgram(models.Model):
 
     @api.model
     def _filter_programs_from_common_rules(self, order, next_order=False):
-
         initial_programs = self.browse(self.ids)
         self._force_sale_order_lines(initial_programs, order)
         programs = super()._filter_programs_from_common_rules(order, next_order)
-        programs = programs._filter_first_order_programs(order)
-        programs = programs._filter_n_first_order_programs(order)
+        programs = programs._filter_order_programs(
+            order, self._filter_first_order_programs
+        )
+        programs = programs._filter_order_programs(
+            order, self._filter_n_first_order_programs
+        )
         return programs
 
     def _force_sale_order_lines(self, programs, order):
@@ -72,49 +73,54 @@ class SaleCouponProgram(models.Model):
             ):
                 order.add_reward_line_values(program)
 
-    def _remove_invalid_reward_lines(self):
-        # TODO rollback forced lines which is not used for creation of reward
-        # lines for other programs
-        return super._remove_invalid_reward_lines()
-
-    @api.constrains("first_n_customer_orders")
+    @api.constrains("next_n_customer_orders")
     def _constrains_first_n_orders_positive(self):
         for record in self:
-            if record.first_n_customer_orders < 0:
+            if record.next_n_customer_orders < 0:
                 raise exceptions.ValidationError(
                     _("`Apply only on the next` should not be a negative value.")
                 )
 
-    def _get_order_count(self, order):
-        return self.env["sale.order"].search_count(
-            [
-                ("partner_id", "=", order.partner_id.id),
-                ("state", "!=", "cancel"),
-                ("id", "!=", order.id),
-            ]
-        )
+    def _get_partner_order_line_count_domain(self, order):
+        self.ensure_one()
+        partner_id = order.partner_id.commercial_partner_id.id
+        return [
+            ("product_id", "=", self.discount_line_product_id.id),
+            ("order_id.partner_id.commercial_partner_id", "=", partner_id),
+            ("order_id.state", "!=", "cancel"),
+        ]
 
-    def _filter_first_order_programs(self, order):
+    def _get_order_count(self, order):
+        self.ensure_one()
+        domain = self._get_partner_order_line_count_domain(order)
+        data = self.env["sale.order.line"].read_group(
+            domain, ["order_id"], ["order_id"]
+        )
+        return sum(m["order_id_count"] for m in data)
+
+    @api.model
+    def _filter_first_order_programs(self, program, order):
         """
         Filter programs where first_order_only is True,
         and the customer have already ordered before.
         """
-        if self._get_order_count(order):
-            return self.filtered(lambda program: not program.first_order_only)
-        return self
+        return not (program._get_order_count(order) and program.first_order_only)
 
-    def _filter_n_first_order_programs(self, order):
+    @api.model
+    def _filter_n_first_order_programs(self, program, order):
         """
-        Filter programs where first_n_customer_orders is set, and
+        Filter programs where next_n_customer_orders is set, and
         the max number of orders have already been reached by the customer.
         """
-        order_count = self._get_order_count(order)
+        return not (
+            program.next_n_customer_orders
+            and program._get_order_count(order) >= program.next_n_customer_orders
+        )
+
+    def _filter_order_programs(self, order, predicate):
         filtered_programs = self.env[self._name]
         for program in self:
-            if (
-                program.first_n_customer_orders
-                and order_count >= program.first_n_customer_orders
-            ):
+            if not predicate(program, order):
                 continue
             filtered_programs |= program
         return filtered_programs

--- a/sale_coupon_advanced/models/sale_order.py
+++ b/sale_coupon_advanced/models/sale_order.py
@@ -56,7 +56,6 @@ class SaleOrder(models.Model):
 
     def _create_new_no_code_promo_reward_lines(self):
         super()._create_new_no_code_promo_reward_lines()
-
         program = self._get_applicable_no_code_promo_program().filtered(
             lambda p: p.reward_type == "use_pricelist"
         )
@@ -102,6 +101,8 @@ class SaleOrder(models.Model):
                 self.write({"order_line": [(0, False, values)]})
 
     def _remove_invalid_reward_lines(self):
+        # TODO: rollback forced lines which is not used for creation of
+        # reward lines for other programs
         super()._remove_invalid_reward_lines()
         new_sale_order = self.new({"partner_id": self.partner_id})
         new_sale_order.onchange_partner_id()

--- a/sale_coupon_advanced/tests/common.py
+++ b/sale_coupon_advanced/tests/common.py
@@ -5,6 +5,8 @@
 from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
 
 
+# TODO: refactor to use SavepointCase. TransactionCase is bottlenecking
+# tests here.
 class TestSaleCoupon(TestSaleCouponCommon):
     def setUp(self):
         super().setUp()

--- a/sale_coupon_advanced/tests/test_sale_coupon_forced_reward_product.py
+++ b/sale_coupon_advanced/tests/test_sale_coupon_forced_reward_product.py
@@ -26,8 +26,8 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
                             "product_uom": self.uom_unit.id,
                             "product_uom_qty": 2.0,
                         },
-                    ),
-                ],
+                    )
+                ]
             }
         )
 

--- a/sale_coupon_advanced/tests/test_sale_coupon_pricelist.py
+++ b/sale_coupon_advanced/tests/test_sale_coupon_pricelist.py
@@ -22,7 +22,7 @@ class TestSaleCouponCumulative(TestSaleCoupon):
                             "applied_on": "0_product_variant",
                             "product_id": self.product_D.id,
                         },
-                    ),
+                    )
                 ],
             }
         )
@@ -33,29 +33,27 @@ class TestSaleCouponCumulative(TestSaleCoupon):
         sol_product_d = order.order_line.filtered(
             lambda line: line.product_id == self.product_D
         )
-
         self.assertEqual(sol_product_d.price_unit, 100.00)
         # update one program to use pricelist settings
-        self.program_c.reward_pricelist_id = self.pricelist
-        self.program_c.reward_type = "use_pricelist"
-
+        self.program_c.write(
+            {"reward_pricelist_id": self.pricelist.id, "reward_type": "use_pricelist"}
+        )
         order.recompute_coupon_lines()
         self.assertEqual(order.pricelist_id, self.pricelist)
         self.assertEqual(sol_product_d.price_unit, 50.00)
 
     def test_program_pricelist_rollbacked(self):
-        self.program_c.reward_pricelist_id = self.pricelist
-        self.program_c.reward_type = "use_pricelist"
+        self.program_c.write(
+            {"reward_pricelist_id": self.pricelist.id, "reward_type": "use_pricelist"}
+        )
         order = self._create_order()
         order.recompute_coupon_lines()
         sol_product_d = order.order_line.filtered(
             lambda line: line.product_id == self.product_D
         )
-
         self.assertEqual(sol_product_d.price_unit, 50.00)
         # disable program with pricelist
         self.program_c.active = False
-
         order.recompute_coupon_lines()
         self.assertNotEqual(order.pricelist_id, self.pricelist)
         self.assertEqual(sol_product_d.price_unit, 100.00)

--- a/sale_coupon_advanced/tests/test_sale_coupon_promotion_program.py
+++ b/sale_coupon_advanced/tests/test_sale_coupon_promotion_program.py
@@ -8,7 +8,6 @@ class TestProgramForFirstSaleOrder(TestSaleCouponCommon):
         super(TestProgramForFirstSaleOrder, self).setUp()
 
         self.env["sale.coupon.program"].search([]).write({"active": False})
-        self.env["sale.coupon"].search([]).write({"active": False})
 
         self.product_A = self.env["product.product"].create(
             {"name": "Product A", "list_price": 60, "sale_ok": True}
@@ -120,7 +119,7 @@ class TestProgramForFirstSaleOrder(TestSaleCouponCommon):
                         "product_uom": self.uom_unit.id,
                         "product_uom_qty": products[product],
                     },
-                ),
+                )
             )
 
         order.write({"order_line": order_lines})
@@ -247,5 +246,5 @@ class TestProgramForFirstSaleOrder(TestSaleCouponCommon):
         discounts = set(order2.order_line.mapped("name")) - {"Product B", "Product A"}
         self.assertEqual(len(discounts), 1, "Order should contain one discount")
         self.assertTrue(
-            "Free Product - Product B" in discounts.pop(), "Discount should be applied",
+            "Free Product - Product B" in discounts.pop(), "Discount should be applied"
         )

--- a/sale_coupon_advanced/tests/test_sale_coupon_promotion_program_n_times.py
+++ b/sale_coupon_advanced/tests/test_sale_coupon_promotion_program_n_times.py
@@ -4,6 +4,7 @@
 from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
 
 
+# TODO: refactor test classes for better reusability
 class TestProgramForNFirstSaleOrder(TestSaleCouponCommon):
     def _create_order(self, product, qty):
         order = self.empty_order
@@ -31,26 +32,33 @@ class TestProgramForNFirstSaleOrder(TestSaleCouponCommon):
             }
         )
 
-    def test_no_n_orders(self):
-        """
-        If `first_n_customer_orders` == 0, program is always appliable.
-        """
-        self.program.write({"first_n_customer_orders": 0})
+    def test_01_no_n_orders(self):
+        """`next_n_customer_orders` == 0, program applied always."""
+        self.program.write({"next_n_customer_orders": 0})
         order = self._create_order(self.product_A, 1)
         order.recompute_coupon_lines()
-        for __ in range(10):
+        for __ in range(3):
             self.assertEqual(order.amount_untaxed, 90)
             order = order.copy()
 
-    def test_max_2_orders(self):
-        """
-        If `first_n_customer_orders` > 0, program is appliable n times.
-        """
+    def test_02_max_2_orders(self):
+        """`next_n_customer_orders` == 2, program applied 2 times."""
         max_orders = 2
-        self.program.write({"first_n_customer_orders": max_orders})
+        partner = self.env["res.partner"].create(
+            {"name": "Test Partner", "is_company": True}
+        )
+        self.program.write({"next_n_customer_orders": max_orders})
         order = self._create_order(self.product_A, 1)
-        order.recompute_coupon_lines()
-        for __ in range(max_orders):
-            self.assertEqual(order.amount_untaxed, 90)
-            order = order.copy()
+        # Create new order without coupon used.
+        order_without_coupon = order.copy()
+        self.assertEqual(order_without_coupon.amount_untaxed, 100)
+        order.recompute_coupon_lines()  # used first time
+        self.assertEqual(order.amount_untaxed, 90)
+        # Create new order with coupon used, but with different partner.
+        order_with_diff_partner = order.copy(default={"partner_id": partner.id})
+        self.assertEqual(order_with_diff_partner.amount_untaxed, 90)
+        self.assertEqual(order.amount_untaxed, 90)
+        order = order.copy()  # used second time
+        self.assertEqual(order.amount_untaxed, 90)
+        order = order.copy()  # tried to use third time.
         self.assertEqual(order.amount_untaxed, 100)

--- a/sale_coupon_advanced/views/sale_coupon.program.xml
+++ b/sale_coupon_advanced/views/sale_coupon.program.xml
@@ -9,13 +9,18 @@
         <field name="arch" type="xml">
             <field name="rule_date_to" position="after">
                 <field name="is_cumulative" />
-                <field name="first_order_only" />
                 <field
-                    name="first_n_customer_orders"
+                    name="first_order_only"
+                    attrs="{'invisible': [('next_n_customer_orders', '>', 0)]}"
+                />
+                <field
+                    name="next_n_customer_orders"
                     attrs="{'invisible': [('first_order_only', '=', True)]}"
                     class="oe_inline"
                 />
-                <span>orders of each client matching the conditions</span>
+                <span
+                    attrs="{'invisible': [('first_order_only', '=', True)]}"
+                >orders of each client matching the conditions</span>
             </field>
             <xpath
                 expr="//group[@name='reward']/ancestor::group/group[4]"


### PR DESCRIPTION
Issue 194

There is already order_count field that shows how many orders have used
related coupon, so it does not make sense to use _get_order_count method
which just returns customer orders, not the one that used coupon.