### PR TITLE
[FIX] sale_coupon_advanced: remove discount lines with initial line

### DIFF
--- a/sale_coupon_advanced/models/sale_order_line.py
+++ b/sale_coupon_advanced/models/sale_order_line.py
@@ -4,8 +4,37 @@ from odoo import fields, models
 
 
 class SaleOrderLine(models.Model):
+    """Extend to add forced_reward_line field and override unlink."""
+
     _inherit = "sale.order.line"
 
     forced_reward_line = fields.Boolean(
         help="Tech field to cleanup automatically created lines"
     )
+
+    def unlink(self):
+        """Override to unlink disc lines when reward ones are unlinked.
+
+        Also removes related sale.coupon.program records.
+        """
+        lines_to_remove = self.env['sale.order.line']
+        SaleCouponProgram = self.env[
+            'sale.coupon.program']
+        for line in self:
+            program = SaleCouponProgram.search([
+                ('reward_type', '=', 'product'),
+                ('reward_product_id', '=', line.product_id.id)
+            ])
+            if not program:
+                continue
+            order = line.order_id
+            # Picking from related order, because it is possible to
+            # remove order lines from different orders at once.
+            order_lines = order.order_line
+            lines_to_remove |= order_lines.filtered(
+                lambda r: r.product_id == program.discount_line_product_id
+            )
+            order.no_code_promo_program_ids -= program
+            order.code_promo_program_id -= program
+        res = super(SaleOrderLine, self | lines_to_remove).unlink()
+        return res

--- a/sale_coupon_advanced/models/sale_order_line.py
+++ b/sale_coupon_advanced/models/sale_order_line.py
@@ -1,5 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from collections import defaultdict
+
 from odoo import fields, models
 
 
@@ -12,19 +14,17 @@ class SaleOrderLine(models.Model):
         help="Tech field to cleanup automatically created lines"
     )
 
-    def unlink(self):
-        """Override to unlink disc lines when reward ones are unlinked.
-
-        Also removes related sale.coupon.program records.
-        """
-        lines_to_remove = self.env['sale.order.line']
-        SaleCouponProgram = self.env[
-            'sale.coupon.program']
+    def _get_discount_data_to_remove(self):
+        data = defaultdict(dict)
+        lines_to_remove = SaleOrderLine = self.env[self._name]
+        SaleCouponProgram = self.env["sale.coupon.program"]
         for line in self:
-            program = SaleCouponProgram.search([
-                ('reward_type', '=', 'product'),
-                ('reward_product_id', '=', line.product_id.id)
-            ])
+            program = SaleCouponProgram.search(
+                [
+                    ("reward_type", "=", "product"),
+                    ("reward_product_id", "=", line.product_id.id),
+                ]
+            )
             if not program:
                 continue
             order = line.order_id
@@ -34,7 +34,31 @@ class SaleOrderLine(models.Model):
             lines_to_remove |= order_lines.filtered(
                 lambda r: r.product_id == program.discount_line_product_id
             )
-            order.no_code_promo_program_ids -= program
-            order.code_promo_program_id -= program
-        res = super(SaleOrderLine, self | lines_to_remove).unlink()
+            order_data = data[order.id]
+            order_data.setdefault("lines", SaleOrderLine)
+            order_data.setdefault("programs", SaleCouponProgram)
+            order_data["lines"] |= lines_to_remove
+            order_data["programs"] |= program
+        return data
+
+    def _collect_discount_lines_and_remove_programs(self):
+        lines = self.env[self._name]
+        data = self._get_discount_data_to_remove()
+        SaleOrder = self.env["sale.order"]
+        for order_id, data in data.items():
+            lines |= data["lines"]
+            programs = data["programs"]
+            order = SaleOrder.browse(order_id)
+            order.no_code_promo_program_ids -= programs
+            order.code_promo_program_id -= programs
+        return lines
+
+    def unlink(self):
+        """Override to unlink disc lines when reward ones are unlinked.
+
+        Also removes related sale.coupon.program records.
+        """
+        if not self._context.get("discount_data_removed"):
+            self |= self._collect_discount_lines_and_remove_programs()
+        res = super(SaleOrderLine, self).unlink()
         return res

--- a/sale_coupon_advanced/tests/test_sale_coupon_forced_reward_product.py
+++ b/sale_coupon_advanced/tests/test_sale_coupon_forced_reward_product.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import CacheMiss
+from odoo.tests.common import Form
 from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
 
 
@@ -46,10 +48,14 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
         self.reward_product = self.program_forced.reward_product_id
         self.discount_product = self.program_forced.discount_line_product_id
 
-    def test_01_filter_programs_from_common_rules__result(self):
-        """
-            Testing `_filter_programs_from_common_rules`
-        """
+    def _get_record_index(self, recordset, record):
+        for i, rec in enumerate(recordset):
+            if rec == record:
+                return i
+        raise ValueError("Record does not exist in recordset")
+
+    def test_01_filter_programs_from_common_rules_result(self):
+        """Check `_filter_programs_from_common_rules`."""
         # TODO adapt the test
         programs = self.program_forced._filter_programs_from_common_rules(
             self.order_forced
@@ -61,61 +67,21 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
             "return the program for the forced reward product",
         )
 
-    def _test_02_get_reward_line_values__result(self):
-        """
-            Testing `sale_order._get_reward_line_values` strict formalism return
+    def test_02_order_line_forced_reward_result(self):
+        """Check if forced product discount was applied.
 
-            IMPORTANT : be aware of the partner's lang as the discount product
-            name is changed towards reward product name (addition of
-            translatable `Free product - ` string)
+        Case 1:
+            - all lines quantity must be 3
+            - reward and discount respectively based on their product id
+            - product discount should canceled the product reward price
+        Case 2: discount product unlinked, when reward product unlinked.
+        Case 3: reward product not unlinked, when discount product is
+            unlinked.
         """
-        taxes = [(4, tax.id, False) for tax in self.product_B.taxes_id]
-        if self.order_forced.fiscal_position_id:
-            taxes = self.order_forced.fiscal_position_id.map_tax(taxes)
-        self.reward_values = [
-            {
-                "sequence": 998,
-                "name": self.reward_product.name,
-                "product_id": self.reward_product.id,
-                "price_unit": self.reward_product.lst_price,
-                "is_reward_line": False,
-                "product_uom_qty": self.program_forced.reward_product_quantity,
-                "product_uom": self.discount_product.uom_id.id,
-                "tax_id": taxes,
-            },
-            {
-                "sequence": 999,
-                "name": self.discount_product.name,
-                "product_id": self.discount_product.id,
-                "price_unit": -self.reward_product.lst_price,
-                "is_reward_line": True,
-                "product_uom_qty": self.program_forced.reward_product_quantity,
-                "product_uom": self.reward_product.uom_id.id,
-                "tax_id": taxes,
-            },
-        ]
-
-        # Sorting by sequences as the interface does
-        reward_values = sorted(
-            self.order_forced._get_reward_line_values(self.program_forced),
-            key=lambda k: k["sequence"],
-        )
-        self.assertEquals(
-            self.reward_values,
-            reward_values,
-            "`sale_order._get_reward_line_values` should return forced reward "
-            "values",
-        )
-
-    def test_03_order_line__forced_reward_result(self):
-        """
-            Testing global result in sale_order.order_line :
-                - all lines quantity must be 3
-                - reward and discount respectively based on their product id
-                - product discount should canceled the product reward price
-        """
-        self.order_forced.recompute_coupon_lines()
-        all_lines = self.order_forced.order_line
+        # Case 1.
+        order = self.order_forced
+        order.recompute_coupon_lines()
+        all_lines = order.order_line
         discount_lines = all_lines.filtered(
             lambda line: line.product_id.id == self.discount_product.id
         )
@@ -129,16 +95,42 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
             "reward line and the product B discount line",
         )
         self.assertTrue(
-            self.order_forced._is_reward_in_order_lines(self.program_forced),
+            order._is_reward_in_order_lines(self.program_forced),
             "The order should contains the Product B reward line",
         )
-        self.assertEquals(
+        self.assertEqual(
             len(discount_lines),
             1,
             "The order should contains the Product B discount line",
         )
-        self.assertEquals(
+        self.assertEqual(
             len(discount_lines_by_price),
             1,
             "The order discount product should contains a negative reward price",
+        )
+        # Case 2.
+        reward_line = all_lines.filtered(
+            lambda r: r.product_id == self.reward_product)
+        reward_line_idx = self._get_record_index(order.order_line, reward_line)
+        # Use Form to mimic actual line remove via interface.
+        with Form(order) as so:
+            so.order_line.remove(reward_line_idx)
+        self.assertEqual(len(order.order_line), 1)
+        self.assertTrue(
+            order.order_line.filtered(
+                lambda r: r.product_id == self.product_A
+            )
+        )
+        # Case 3.
+        order.recompute_coupon_lines()
+        # Sanity check.
+        self.assertEqual(len(order.order_line), 3)
+        discount_line = order.order_line.filtered(
+            lambda r: r.product_id == self.discount_product)
+        discount_line.unlink()
+        self.assertEqual(len(order.order_line), 2)
+        product_ids = order.order_line.mapped('product_id').ids
+        self.assertEqual(
+            sorted(product_ids),
+            sorted((self.product_A | self.reward_product).ids)
         )


### PR DESCRIPTION
Improving the way discount lines are handled, when related promotion order line is removed. It will not remove related discount line, if promotion line is removed (before, you would need to remove it manually).