### PR TITLE
[IMP] sale_coupon_advanced: is_promotion_pricelist

### DIFF
--- a/sale_coupon_advanced/__manifest__.py
+++ b/sale_coupon_advanced/__manifest__.py
@@ -10,6 +10,7 @@
     "license": "AGPL-3",
     "depends": ["sale_coupon"],
     "data": [
+        "views/product_pricelist_views.xml",
         "views/sale_coupon_program_views.xml",
         "wizard/sale_coupon_generate_views.xml",
     ],

--- a/sale_coupon_advanced/i18n/fr.po
+++ b/sale_coupon_advanced/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-13 08:16+0000\n"
-"PO-Revision-Date: 2020-10-13 08:16+0000\n"
+"POT-Creation-Date: 2020-10-21 10:44+0000\n"
+"PO-Revision-Date: 2020-10-21 10:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -117,11 +117,17 @@ msgid "Number of Alphanumeric symbols"
 msgstr "Nombre de symboles alphanumériques"
 
 #. module: sale_coupon_advanced
+#: model:ir.model,name:sale_coupon_advanced.model_product_pricelist
 #: model:ir.model.fields,field_description:sale_coupon_advanced.field_sale_coupon__reward_pricelist_id
 #: model:ir.model.fields,field_description:sale_coupon_advanced.field_sale_coupon_program__reward_pricelist_id
 #: model:ir.model.fields.selection,name:sale_coupon_advanced.selection__sale_coupon_reward__reward_type__use_pricelist
 msgid "Pricelist"
-msgstr ""
+msgstr "Liste de prix"
+
+#. module: sale_coupon_advanced
+#: model:ir.model.fields,field_description:sale_coupon_advanced.field_product_pricelist__is_promotion_pricelist
+msgid "Promotion Pricelist"
+msgstr "Liste de prix promotion"
 
 #. module: sale_coupon_advanced
 #: code:addons/sale_coupon_advanced/models/sale_order.py:0

--- a/sale_coupon_advanced/models/__init__.py
+++ b/sale_coupon_advanced/models/__init__.py
@@ -1,3 +1,4 @@
+from . import product_pricelist
 from . import sale_coupon_program
 from . import sale_order
 from . import sale_order_line

--- a/sale_coupon_advanced/models/product_pricelist.py
+++ b/sale_coupon_advanced/models/product_pricelist.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class ProductPricelist(models.Model):
+    """Extend to add is_promotion_pricelist field."""
+
+    _inherit = "product.pricelist"
+
+    is_promotion_pricelist = fields.Boolean("Promotion Pricelist")

--- a/sale_coupon_advanced/models/sale_coupon_program.py
+++ b/sale_coupon_advanced/models/sale_coupon_program.py
@@ -8,7 +8,11 @@ class SaleCouponProgram(models.Model):
     _inherit = "sale.coupon.program"
 
     is_cumulative = fields.Boolean(string="None-cumulative Promotion")
-    reward_pricelist_id = fields.Many2one("product.pricelist", string="Pricelist")
+    reward_pricelist_id = fields.Many2one(
+        "product.pricelist",
+        string="Pricelist",
+        domain=[("is_promotion_pricelist", "=", True)],
+    )
     # Add possibility to use discount only on first order of a customer
     first_order_only = fields.Boolean(
         string="Apply only first",

--- a/sale_coupon_advanced/views/product_pricelist_views.xml
+++ b/sale_coupon_advanced/views/product_pricelist_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_pricelist_view" model="ir.ui.view">
+        <field name="name">product.pricelist.form.promotion</field>
+        <field name="model">product.pricelist</field>
+        <field name="inherit_id" ref="product.product_pricelist_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//group[@name='pricelist_settings']/field[@name='currency_id']"
+                position="before"
+            >
+                <field name="is_promotion_pricelist" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_coupon_advanced/views/sale_coupon_program_views.xml
+++ b/sale_coupon_advanced/views/sale_coupon_program_views.xml
@@ -39,6 +39,7 @@
                         name="reward_pricelist_id"
                         attrs="{'invisible': [('reward_type', 'in', ('discount', 'free_shipping', 'product'))], 'required': [('reward_type', '=', 'pricelist')]}"
                         placeholder="Select reward pricelist"
+                        context="{'default_is_promotion_pricelist': True}"
                     />
                 </group>
             </xpath>


### PR DESCRIPTION
Need a way to distinguish pricelists which are used for promotions.