### PR TITLE
[FIX] sale_coupon_advanced: first_order

### DIFF
--- a/sale_coupon_advanced/models/sale_order.py
+++ b/sale_coupon_advanced/models/sale_order.py
@@ -176,4 +176,4 @@ class SaleOrder(models.Model):
         # Lets check promotions on virtual sale order.
         if not isinstance(self.id, models.NewId):
             domain.append(("id", "!=", self.id))
-        return not bool(self.search_count(domain))
+        return not self.search_count(domain)

--- a/sale_coupon_advanced/models/sale_order.py
+++ b/sale_coupon_advanced/models/sale_order.py
@@ -160,14 +160,20 @@ class SaleOrder(models.Model):
         return super(SaleOrder, self).write(vals)
 
     def first_order(self):
+        """Check if this is first partner order.
+
+        Returns:
+            True if there are no other non-cancelled orders for this
+            commercial partner, False otherwise.
+
+        """
         self.ensure_one()
         partner_id = self.partner_id.commercial_partner_id.id
-        return not bool(
-            self.search_count(
-                [
-                    ("id", "!=", self.id),
-                    ("partner_id.commercial_partner_id", "=", partner_id),
-                    ("state", "!=", "cancel"),
-                ]
-            )
-        )
+        domain = [
+            ("partner_id.commercial_partner_id", "=", partner_id),
+            ("state", "!=", "cancel"),
+        ]
+        # Lets check promotions on virtual sale order.
+        if not isinstance(self.id, models.NewId):
+            domain.append(("id", "!=", self.id))
+        return not bool(self.search_count(domain))

--- a/sale_coupon_advanced/tests/test_sale_coupon_promotion_program.py
+++ b/sale_coupon_advanced/tests/test_sale_coupon_promotion_program.py
@@ -236,6 +236,12 @@ class TestProgramForFirstSaleOrder(TestSaleCouponCommon):
         self.process_coupon(order2, "30_discount")
         self.assertEqual(len(order2.order_line.ids), 2)
 
+    def test_first_order_virtual(self):
+        """Check if first_order can be called on virtual order."""
+        partner_virtual = self.env["res.partner"].new({"name": "dummy"})
+        so_virtual = self.env["sale.order"].new({"partner_id": partner_virtual.id})
+        self.assertTrue(so_virtual.first_order())
+
     def test_free_product_promotion(self):
         # deactivate other programs
         self.program1.write({"active": False})


### PR DESCRIPTION
Checking for virtual ID on SO, so it would be possible to check
promotions from virtual sale order (that is not intended to be created).

This is a workaround, because SOs are tightly integrated with promotions
and can't be used without each other.