### PR TITLE
[FIX] sale_coupon_advanced: clean up forced lines

### DIFF
--- a/sale_coupon_advanced/models/sale_coupon_program.py
+++ b/sale_coupon_advanced/models/sale_coupon_program.py
@@ -58,6 +58,9 @@ class SaleCouponProgram(models.Model):
     @api.model
     def _filter_programs_from_common_rules(self, order, next_order=False):
         initial_programs = self.browse(self.ids)
+        # FIXME: this is bad design. _filter_programs_from_common_rules
+        # supposed to just filter programs, but it has side effect,
+        # where it can also add order lines.
         self._force_sale_order_lines(initial_programs, order)
         programs = super()._filter_programs_from_common_rules(order, next_order)
         programs = programs._filter_first_order_programs(order)
@@ -66,6 +69,8 @@ class SaleCouponProgram(models.Model):
         )
         return programs
 
+    # TODO: method docstring does not make sense. It does not do
+    # anything what is described.
     def _force_sale_order_lines(self, programs, order):
         """Return the programs when `is_reward_product_forced` is selected
         and reward product not already ordered"""

--- a/sale_coupon_advanced/models/sale_coupon_program.py
+++ b/sale_coupon_advanced/models/sale_coupon_program.py
@@ -4,6 +4,14 @@
 from odoo import _, api, exceptions, fields, models
 
 
+def _predicate_promo_code(program, order, coupon_code):
+    return bool(program.filtered(lambda r: r.promo_code == coupon_code))
+
+
+def _predicate_no_code_needed(program, order, coupon_code):
+    return program.promo_code_usage == "no_code_needed"
+
+
 class SaleCouponProgram(models.Model):
     _inherit = "sale.coupon.program"
 
@@ -31,11 +39,28 @@ class SaleCouponProgram(models.Model):
         help="If checked, the reward product will be added if not ordered.",
     )
 
-    def _check_promo_code(self, order, coupon_code):
+    def _check_promo_code_forced(self, order, coupon_code=None, predicate=None):
+        def default_predicate(program, order, coupon_code):
+            return True
 
+        if not predicate:
+            predicate = default_predicate
+        # Using same check again, to know which error was returned. Can't
+        # use error message, because it is unstable check. Message can
+        # be translated and it would then return different text than
+        # expected.
+        # Can also use extra predicate to further filter program.
+        return (
+            self.is_reward_product_forced
+            and self.promo_applicability == "on_current_order"
+            and self.reward_type == "product"
+            and not order._is_reward_in_order_lines(self)
+            and predicate(self, order, coupon_code)
+        )
+
+    def _check_promo_code(self, order, coupon_code):
         if self.first_order_only and not order.first_order():
             return {"error": _("Coupon can be used only for the first sale order!")}
-
         order_count = self._get_order_count(order)
         max_order_number = self.next_n_customer_orders
         if max_order_number and order_count >= max_order_number:
@@ -44,43 +69,29 @@ class SaleCouponProgram(models.Model):
                     max_order_number
                 )
             }
-        # Do not return product unordered error message if
-        # `is_reward_product_forced` is selected
-        message = _(
-            "The reward products should be in the sales order lines to"
-            " apply the discount."
-        )
         res = super()._check_promo_code(order, coupon_code)
-        if res.get("error") == message and self.is_reward_product_forced:
+        if res.get("error") and self._check_promo_code_forced(
+            order, coupon_code=coupon_code, predicate=_predicate_promo_code
+        ):
             return {}
         return res
 
     @api.model
     def _filter_programs_from_common_rules(self, order, next_order=False):
-        initial_programs = self.browse(self.ids)
-        # FIXME: this is bad design. _filter_programs_from_common_rules
-        # supposed to just filter programs, but it has side effect,
-        # where it can also add order lines.
-        self._force_sale_order_lines(initial_programs, order)
+        # FIXME: this is not great, because this method responsibility
+        # is to just filter programs, not silently create lines.
+        for program in self:
+            order._filter_force_create_counter_line_for_reward_product(
+                program,
+                # This call is only meant for auto applied promotions.
+                predicate=_predicate_no_code_needed,
+            )
         programs = super()._filter_programs_from_common_rules(order, next_order)
         programs = programs._filter_first_order_programs(order)
         programs = programs._filter_order_programs(
             order, self._filter_n_first_order_programs
         )
         return programs
-
-    # TODO: method docstring does not make sense. It does not do
-    # anything what is described.
-    def _force_sale_order_lines(self, programs, order):
-        """Return the programs when `is_reward_product_forced` is selected
-        and reward product not already ordered"""
-        for program in programs:
-            if (
-                program.reward_type == "product"
-                and program.is_reward_product_forced
-                and not order._is_reward_in_order_lines(program)
-            ):
-                order.add_reward_line_values(program)
 
     @api.constrains("next_n_customer_orders")
     def _constrains_first_n_orders_positive(self):

--- a/sale_coupon_advanced/models/sale_order.py
+++ b/sale_coupon_advanced/models/sale_order.py
@@ -17,14 +17,30 @@ class SaleOrder(models.Model):
         except ValueError:
             return seq
 
-    def add_reward_line_values(self, program):
-        """Add the rewarded product if a reward line has been found for this
-        product
+    def _create_reward_line(self, program):
+        self._filter_force_create_counter_line_for_reward_product(program)
+        super()._create_reward_line(program)
+
+    def _filter_force_create_counter_line_for_reward_product(
+        self, program, predicate=None
+    ):
+        """Create counter line if its needed for program."""
+        # NOTE. Not passing coupon_code, because from this call we dont
+        # have it, but its not needed either (so will just default to
+        # None).
+        if program._check_promo_code_forced(self, predicate=predicate):
+            self._create_counter_line_for_reward_product(program)
+
+    def _create_counter_line_for_reward_product(self, program):
+        """Create force line to counter balance discount line.
+
+        This line must exist before actual discount/reward line is
+        created.
+        Because forced program can skip _check_promo_code, we need to
+        add counter line automatically as standard functionality expects
+        such line (standard functionality expects you to create this
+        line manually only).
         """
-        # NOTE. This method dosctring is misleading, it says, it adds
-        # rewarded product if there is reward line found, but it
-        # actually does not check any reward line, instead it adds
-        # before any reward line is added.
         reward_product = program.reward_product_id
         taxes = reward_product.taxes_id
         if self.fiscal_position_id:
@@ -116,40 +132,10 @@ class SaleOrder(models.Model):
                 self.write({"order_line": [(0, False, values)]})
 
     def _remove_invalid_reward_lines(self):
-        # TODO: rollback forced lines which is not used for creation of
-        # reward lines for other programs
         super()._remove_invalid_reward_lines()
-        self._remove_invalid_forced_lines()
         new_sale_order = self.new({"partner_id": self.partner_id})
         new_sale_order.onchange_partner_id()
         self._update_pricelist(new_sale_order.pricelist_id)
-
-    def _remove_invalid_forced_lines(self):
-        # NOTE. This is a redundant bandage fix. Such lines should not
-        # appear on SO in a first place, but because existing
-        # functionality is interlined so much, its now hard to properly
-        # change it without breaking other things.
-        def has_related_reward_lines(product_forced):
-            discount_products = SaleCouponProgram.search(
-                [
-                    ("reward_type", "=", "product"),
-                    ("reward_product_id", "=", product_forced.id),
-                    ("is_reward_product_forced", "=", True),
-                ]
-            ).mapped("discount_line_product_id")
-            order_products = self.order_line.mapped("product_id")
-            # Find if related discount product is also on same order.
-            return any(p for p in discount_products if p in order_products)
-
-        SaleCouponProgram = self.env["sale.coupon.program"]
-        lines_to_remove = self.env["sale.order.line"]
-        for line in self.order_line.filtered("forced_reward_line"):
-            if not has_related_reward_lines(line.product_id):
-                lines_to_remove |= line
-        # Flag to know if anything was removed.
-        removed = bool(lines_to_remove)
-        lines_to_remove.unlink()
-        return removed
 
     def _update_pricelist(self, pricelist):
         self.pricelist_id = pricelist

--- a/sale_coupon_advanced/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_advanced/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Anna Janiszewska <anna.janiszewska@camptocamp.com>
 * Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
 * Stéphane Mangin <stephane.mangin@freesbee.fr>
+* Andrius Laukavičius <andrius@focusate.eu>

--- a/sale_coupon_advanced/tests/test_sale_coupon_forced_reward_product.py
+++ b/sale_coupon_advanced/tests/test_sale_coupon_forced_reward_product.py
@@ -34,7 +34,10 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
 
         self.program_forced = self.env["sale.coupon.program"].create(
             {
-                "name": "Buy anything, B are free",
+                "name": "Promotion Buy anything, B is free",
+                # Must specify program_type, because it does not set
+                # it on default and just set False value.
+                "program_type": "promotion_program",
                 "promo_code_usage": "no_code_needed",
                 "reward_type": "product",
                 "reward_product_id": self.product_B.id,
@@ -60,17 +63,20 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
         self.assertNotIn(program, order.code_promo_program_id)
         self.assertNotIn(program, order.no_code_promo_program_ids)
 
-    def test_01_filter_programs_from_common_rules_result(self):
-        """Check `_filter_programs_from_common_rules`."""
-        # TODO adapt the test
-        programs = self.program_forced._filter_programs_from_common_rules(
-            self.order_forced
-        )
-        self.assertIn(
-            self.program_forced.id,
-            programs.ids,
-            "`sale_coupon_program._filter_programs_from_common_rules` should "
-            "return the program for the forced reward product",
+    def _test_forced_reward_product_lines_pair(self, order, program):
+        forced_line = order.order_line.filtered("forced_reward_line")
+        self.assertEqual(len(forced_line), 1)
+        self.assertEqual(forced_line.product_id, program.reward_product_id)
+        reward_line = order.order_line.filtered("is_reward_line")
+        self.assertEqual(len(reward_line), 1)
+        self.assertEqual(reward_line.product_id, program.discount_line_product_id)
+
+    def test_01_create_reward_line_forced(self):
+        """Check if forced reward with counter lines are created."""
+        self.order_forced._create_reward_line(self.program_forced)
+        self.assertEqual(len(self.order_forced.order_line), 3)
+        self._test_forced_reward_product_lines_pair(
+            self.order_forced, self.program_forced
         )
 
     def test_02_order_line_forced_reward_result(self):
@@ -164,14 +170,19 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
         """Apply forced rewards with coupon code.
 
         Case 1: apply using code.
-        Case 2: check if its not applied when recomputing promotions.
+        Case 2: check if its not applied when recomputing promotions (
+            promo inactive).
+        Case 3: check if auto promotion applied, but not ones with code,
+            when recomputing promotions (promo active).
+
+
         """
-        # Case 1.
-        # Disable automatic promotion.
         self.program_forced.active = False
+        # Case 1.
         program_product_1 = self.env["sale.coupon.program"].create(
             {
-                "name": "Buy anything, B is free",
+                "name": "Coupon buy anything, B is free",
+                "program_type": "promotion_program",
                 "promo_code_usage": "code_needed",
                 "promo_code": "MYPROMO1",
                 "reward_type": "product",
@@ -203,7 +214,28 @@ class TestSaleCouponForcedRewardProduct(TestSaleCouponCommon):
         # Total amount must not change, extra product is nullified by
         # discount line.
         self.assertEqual(self.order_forced.amount_total, amount_total)
+        self._test_forced_reward_product_lines_pair(
+            self.order_forced, program_product_1
+        )
         # Case 2.
         self.order_forced.order_line.unlink()
         self.order_forced.recompute_coupon_lines()
         self.assertFalse(self.order_forced.order_line)
+        # Case 3.
+        self.order_forced.order_line = [
+            (
+                0,
+                False,
+                {
+                    "product_id": self.product_A.id,
+                    "name": "1 Product A",
+                    "product_uom": self.uom_unit.id,
+                    "product_uom_qty": 2.0,
+                },
+            )
+        ]
+        self.program_forced.active = True
+        self.order_forced.recompute_coupon_lines()
+        self._test_forced_reward_product_lines_pair(
+            self.order_forced, self.program_forced
+        )

--- a/sale_coupon_advanced/wizard/sale_coupon_apply_code.py
+++ b/sale_coupon_advanced/wizard/sale_coupon_apply_code.py
@@ -28,4 +28,7 @@ class SaleCouponApplyCode(models.TransientModel):
             )
             if coupon and coupon.reward_pricelist_id:
                 order._update_pricelist(coupon.reward_pricelist_id)
+        # Clean up potential incorrectly forced lines.
+        sales_order = self.env["sale.order"].browse(self.env.context.get("active_id"))
+        sales_order._remove_invalid_forced_lines()
         return error_status

--- a/sale_coupon_advanced/wizard/sale_coupon_apply_code.py
+++ b/sale_coupon_advanced/wizard/sale_coupon_apply_code.py
@@ -28,7 +28,4 @@ class SaleCouponApplyCode(models.TransientModel):
             )
             if coupon and coupon.reward_pricelist_id:
                 order._update_pricelist(coupon.reward_pricelist_id)
-        # Clean up potential incorrectly forced lines.
-        sales_order = self.env["sale.order"].browse(self.env.context.get("active_id"))
-        sales_order._remove_invalid_forced_lines()
         return error_status


### PR DESCRIPTION
Applying bandage fix to clean up incorrectly created forced sale order
lines.

Bugs fixed:
    - no longer adds unrelated programs reward products on SO when
        applying coupon code from forced program.
    - no longer adds products from forced promotions that need code to
        be entered, when recomputing promotions.
    - handling order line sequence generation, when it is called, when
        no lines exists.