### PR TITLE
[FIX] sale_coupon_multi_use: sale confirm

### DIFF
--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#   * sale_coupon_multi_use
+# 	* sale_coupon_multi_use
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-06 12:26+0000\n"
-"PO-Revision-Date: 2020-11-06 12:26+0000\n"
+"POT-Creation-Date: 2020-11-10 12:45+0000\n"
+"PO-Revision-Date: 2020-11-10 12:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,12 +26,15 @@ msgid "Consumption Lines"
 msgstr "Lignes de consommation"
 
 #. module: sale_coupon_multi_use
-#: code:addons/sale_coupon_multi_use/models/sale_coupon.py:0
+#: code:addons/sale_coupon_multi_use/models/sale_coupon_consumption_line.py:0
 #, python-format
 msgid ""
 "Consumption Lines can't be deleted directly. To do that, delete related sale"
 " order line."
-msgstr "Les lignes de consommation ne peuvent pas être modifiées via cette interface. Pour cela, il faut modifier les lignes correspondantes sur les bons de commande."
+msgstr ""
+"Les lignes de consommation ne peuvent pas être modifiées via cette "
+"interface. Pour cela, il faut modifier les lignes correspondantes sur les "
+"bons de commande."
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__coupon_id
@@ -63,12 +66,14 @@ msgstr "Montant restant"
 #, python-format
 msgid ""
 "Fixed Amount can't be changed when there are Multi Use coupons already."
-msgstr "Le montant restant ne peut pas être modifié quand un bon de réduction a déjà été utilisé plusieurs fois."
+msgstr ""
+"Le montant restant ne peut pas être modifié quand un bon de réduction a déjà"
+" été utilisé plusieurs fois."
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line____last_update
@@ -101,7 +106,8 @@ msgstr "Bon de réduction sécable"
 msgid ""
 "Multi Use Coupons program must have Coupon Program Type, Discount Reward and"
 " Fixed Amount as Apply Discount"
-msgstr "Les bons de réductions sécables doivent être de type Remise et Montant fixe"
+msgstr ""
+"Les bons de réductions sécables doivent être de type Remise et Montant fixe"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_consumption_line

--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -73,7 +73,7 @@ msgstr ""
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__id
 msgid "ID"
-msgstr ""
+msgstr "Identifiant"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line____last_update

--- a/sale_coupon_multi_use/models/__init__.py
+++ b/sale_coupon_multi_use/models/__init__.py
@@ -1,3 +1,4 @@
 from . import sale_coupon_program
 from . import sale_coupon
 from . import sale_coupon_consumption_line
+from . import sale_order

--- a/sale_coupon_multi_use/models/__init__.py
+++ b/sale_coupon_multi_use/models/__init__.py
@@ -1,2 +1,3 @@
 from . import sale_coupon_program
 from . import sale_coupon
+from . import sale_coupon_consumption_line

--- a/sale_coupon_multi_use/models/sale_coupon.py
+++ b/sale_coupon_multi_use/models/sale_coupon.py
@@ -1,6 +1,14 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import pickle
+
 from odoo import api, fields, models
+
+
+def _pickle_copy(data):
+    """Do deep copy of specified data."""
+    # Seems to work much faster for small data than copy.deepcopy.
+    return pickle.loads(pickle.dumps(data))
 
 
 class SaleCoupon(models.Model):
@@ -29,32 +37,15 @@ class SaleCoupon(models.Model):
         for rec in self:
             rec.discount_fixed_amount_delta = rec._get_discount_fixed_amount_delta()
 
-    def _is_multi_use_triggered(self, vals):
-        # We expect multi_use coupon will be updated one by one only.
-        return (
-            len(self) == 1
-            and self.multi_use
-            # Must have amount to split.
-            and self.discount_fixed_amount_delta > 0
-            # Indicating for coupon to be consumed.
-            and vals.get("state") == "used"
-        )
-
-    def _get_compared_discount_with_delta(self, coupon_order_data):
-        sale_order = coupon_order_data["order"]
-        amount_total_orig = coupon_order_data["amount_total"]
-        discount = amount_total_orig - sale_order.amount_total
-        new_delta = self.discount_fixed_amount_delta - discount
-        return new_delta, discount
-
-    def _adjust_discount_on_sale_order(self, order, amount_to_adjust):
-        self.ensure_one()
-        discount_product = self.program_id.discount_line_product_id
-        # Supposed to be only one such line.
-        coupon_line = order.order_line.filtered(
-            lambda r: r.product_id == discount_product
-        )
-        coupon_line.price_unit += amount_to_adjust
+    def _filter_multi_use_triggered(self, vals):
+        # Indicating for coupon to be consumed
+        if vals.get("state") == "used":
+            return self.filtered(
+                # Must have amount to split.
+                lambda r: r.multi_use
+                and r.discount_fixed_amount_delta > 0
+            )
+        return self.env[self._name]
 
     def _get_related_sale_order_line(self, sale_order):
         self.ensure_one()
@@ -64,32 +55,24 @@ class SaleCoupon(models.Model):
             lambda r: r.product_id == discount_product
         )[0]
 
-    def _prepare_consumption_line(self, amount_consumed, sale_order):
+    def _prepare_consumption_line(self, sale_order_line):
         self.ensure_one()
-        line = self._get_related_sale_order_line(sale_order)
         return {
             "coupon_id": self.id,
-            "amount": amount_consumed,
-            "sale_order_line_id": line.id,
+            "amount": abs(sale_order_line.price_total),
+            "sale_order_line_id": sale_order_line.id,
         }
 
-    def _create_consumption_line(self, amount_consumed, sale_order):
-        vals = self._prepare_consumption_line(amount_consumed, sale_order)
+    def _create_consumption_line(self, sale_order_line):
+        vals = self._prepare_consumption_line(sale_order_line)
         return self.env["sale.coupon.consumption_line"].create(vals)
 
-    def _consume_line(self, discount, sale_order):
+    def _handle_multi_use(self, coupon_sale_order):
         self.ensure_one()
-        amount_consumed = min(discount, self.discount_fixed_amount_delta)
-        consumption_line = self._create_consumption_line(amount_consumed, sale_order)
-        consumption_line._normalize_discount()
-        return consumption_line
-
-    def _handle_multi_use(self, coupon_order_data):
-        self.ensure_one()
-        new_delta, discount = self._get_compared_discount_with_delta(coupon_order_data)
-        self._consume_line(discount, coupon_order_data["order"])
-        # Indicates whether coupon was fully consumed.
-        return new_delta <= 0
+        related_sol = self._get_related_sale_order_line(coupon_sale_order)
+        if related_sol not in self.consumption_line_ids.mapped("sale_order_line_id"):
+            self._create_consumption_line(related_sol)
+        return self.discount_fixed_amount_delta > 0
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -105,12 +88,24 @@ class SaleCoupon(models.Model):
         return super().create(vals_list)
 
     def write(self, vals):
-        """Extend to manage multi_use coupons."""
-        if self._is_multi_use_triggered(vals):
-            coupon_order_data = self._context.get("coupon_order_data")
-            if coupon_order_data:
-                coupon_consumed = self._handle_multi_use(coupon_order_data)
-                if not coupon_consumed:
-                    # Makes it so coupon that coupon is not used up yet.
-                    del vals["state"]
-        return super().write(vals)
+        """Extend to manage multi_use coupons.
+
+        Each coupon record is handled separately, because some might
+        be valid, some not after handling multi use.
+        """
+        coupon_sale_order = self._context.get("coupon_sale_order")
+        other_coupons = self  # by default all coupons.
+        if coupon_sale_order:
+            multi_use_coupons = self._filter_multi_use_triggered(vals)
+            other_coupons = self - multi_use_coupons
+            for multi_use_coupon in multi_use_coupons:
+                copied_vals = _pickle_copy(vals)
+                coupon_still_valid = multi_use_coupon._handle_multi_use(
+                    coupon_sale_order
+                )
+                if coupon_still_valid:
+                    # Not marking it as consumed.
+                    del copied_vals["state"]
+                if copied_vals:  # could be empty dict, so no point writing
+                    super(SaleCoupon, multi_use_coupon).write(copied_vals)
+        return super(SaleCoupon, other_coupons).write(vals)

--- a/sale_coupon_multi_use/models/sale_coupon.py
+++ b/sale_coupon_multi_use/models/sale_coupon.py
@@ -1,5 +1,6 @@
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
 
 
 class SaleCoupon(models.Model):
@@ -9,7 +10,7 @@ class SaleCoupon(models.Model):
 
     # Takes value from related program (coupon_multi_use field), when
     # it is generated.
-    multi_use = fields.Boolean("Multi Use", readonly=True)
+    multi_use = fields.Boolean(readonly=True)
     consumption_line_ids = fields.One2many(
         "sale.coupon.consumption_line", "coupon_id", "Consumption Lines", readonly=True,
     )
@@ -113,42 +114,3 @@ class SaleCoupon(models.Model):
                     # Makes it so coupon that coupon is not used up yet.
                     del vals["state"]
         return super().write(vals)
-
-
-class SaleCouponConsumptionLine(models.Model):
-    """Model that stores data for single coupon multiple uses."""
-
-    _name = "sale.coupon.consumption_line"
-    _description = "Sale Coupon Consumption Line"
-
-    coupon_id = fields.Many2one("sale.coupon", "Coupon", required=True, index=True)
-    # ondelete takes care of automatically removing consumption line,
-    # when discount line is removed on related sale order.
-    sale_order_line_id = fields.Many2one(
-        "sale.order.line", "Sale Order Line", required=True, ondelete="cascade"
-    )
-    amount = fields.Float()
-
-    def _normalize_discount(self):
-        """Adjust SOL discount to match consumed discount."""
-        self.ensure_one()
-        # Discount initially won't match, when standard functionality
-        # applies full discount from coupon. But because we split
-        # coupon amount, we want to apply maximum possible discount.
-        sol = self.sale_order_line_id
-        sol_discount = abs(sol.price_unit)
-        amount_to_adjust = sol_discount - self.amount
-        if amount_to_adjust > 0:
-            # Reducing negative amount here.
-            sol.price_unit += amount_to_adjust
-
-    def unlink(self):
-        """Override to prevent direct unlink."""
-        if not self._context.get("force_unlink_coupon_consumption_lines"):
-            raise UserError(
-                _(
-                    "Consumption Lines can't be deleted directly. To do that, "
-                    "delete related sale order line."
-                )
-            )
-        return super().unlink()

--- a/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
+++ b/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
@@ -18,19 +18,6 @@ class SaleCouponConsumptionLine(models.Model):
     )
     amount = fields.Float()
 
-    def _normalize_discount(self):
-        """Adjust SOL discount to match consumed discount."""
-        self.ensure_one()
-        # Discount initially won't match, when standard functionality
-        # applies full discount from coupon. But because we split
-        # coupon amount, we want to apply maximum possible discount.
-        sol = self.sale_order_line_id
-        sol_discount = abs(sol.price_unit)
-        amount_to_adjust = sol_discount - self.amount
-        if amount_to_adjust > 0:
-            # Reducing negative amount here.
-            sol.price_unit += amount_to_adjust
-
     def unlink(self):
         """Override to prevent direct unlink."""
         if not self._context.get("force_unlink_coupon_consumption_lines"):

--- a/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
+++ b/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
@@ -18,6 +18,14 @@ class SaleCouponConsumptionLine(models.Model):
     )
     amount = fields.Float()
 
+    def _get_consumption_lines_to_unlink(self, order_lines):
+        return self.filtered(lambda r: r.sale_order_line_id in order_lines)
+
+    def _unlink_consumption_lines(self, order_lines):
+        to_unlink = self._get_consumption_lines_to_unlink(order_lines)
+        if to_unlink:
+            to_unlink.with_context(force_unlink_coupon_consumption_lines=True).unlink()
+
     def unlink(self):
         """Override to prevent direct unlink."""
         if not self._context.get("force_unlink_coupon_consumption_lines"):

--- a/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
+++ b/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleCouponConsumptionLine(models.Model):
+    """Model that stores data for single coupon multiple uses."""
+
+    _name = "sale.coupon.consumption_line"
+    _description = "Sale Coupon Consumption Line"
+
+    coupon_id = fields.Many2one("sale.coupon", "Coupon", required=True, index=True)
+    # ondelete takes care of automatically removing consumption line,
+    # when discount line is removed on related sale order.
+    sale_order_line_id = fields.Many2one(
+        "sale.order.line", "Sale Order Line", required=True, ondelete="cascade"
+    )
+    amount = fields.Float()
+
+    def _normalize_discount(self):
+        """Adjust SOL discount to match consumed discount."""
+        self.ensure_one()
+        # Discount initially won't match, when standard functionality
+        # applies full discount from coupon. But because we split
+        # coupon amount, we want to apply maximum possible discount.
+        sol = self.sale_order_line_id
+        sol_discount = abs(sol.price_unit)
+        amount_to_adjust = sol_discount - self.amount
+        if amount_to_adjust > 0:
+            # Reducing negative amount here.
+            sol.price_unit += amount_to_adjust
+
+    def unlink(self):
+        """Override to prevent direct unlink."""
+        if not self._context.get("force_unlink_coupon_consumption_lines"):
+            raise UserError(
+                _(
+                    "Consumption Lines can't be deleted directly. To do that, "
+                    "delete related sale order line."
+                )
+            )
+        return super().unlink()

--- a/sale_coupon_multi_use/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use/models/sale_coupon_program.py
@@ -59,3 +59,35 @@ class SaleCouponProgram(models.Model):
                         "Discount Reward and Fixed Amount as Apply Discount"
                     )
                 )
+
+    def _compute_program_multi_use_amount(
+        self, multi_use_coupon, sale_order, currency_to
+    ):
+        # Only using remaining amount (original implementation
+        # always uses full amount specified on related program).
+        amount_delta = multi_use_coupon.discount_fixed_amount_delta
+        amount = min(amount_delta, sale_order.amount_total)
+        return self.currency_id._convert(
+            amount, currency_to, self.company_id, fields.Date.today()
+        )
+
+    def _compute_program_amount(self, field, currency_to):
+        """Extend to consume correct multi-use coupon amount."""
+        self.ensure_one()
+        coupon_code = self._context.get("coupon_code")
+        sale_order = self._context.get("coupon_sale_order")
+        if coupon_code and sale_order and field == "discount_fixed_amount":
+            multi_use_coupon = self.env["sale.coupon"].search(
+                [
+                    ("multi_use", "=", True),
+                    ("code", "=", coupon_code),
+                    ("state", "=", "new"),
+                ],
+                limit=1,
+            )
+            if multi_use_coupon:
+                return self._compute_program_multi_use_amount(
+                    multi_use_coupon, sale_order, currency_to
+                )
+
+        return super()._compute_program_amount(field, currency_to)

--- a/sale_coupon_multi_use/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use/models/sale_coupon_program.py
@@ -27,7 +27,7 @@ class SaleCouponProgram(models.Model):
 
     def _get_multi_use_coupons(self):
         self.ensure_one()
-        return self.coupon_ids.filtered(lambda r: r.multi_use)
+        return self.coupon_ids.filtered("multi_use")
 
     @api.constrains("discount_fixed_amount")
     def _check_discount_fixed_amount(self):

--- a/sale_coupon_multi_use/models/sale_order.py
+++ b/sale_coupon_multi_use/models/sale_order.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    """Extend to modify action_confirm for multi-use coupons."""
+
+    _inherit = "sale.order"
+
+    def action_confirm(self):
+        """Extend to pass coupon_order_data context."""
+        for order in self:
+            order = order.with_context(coupon_sale_order=order)
+            super(SaleOrder, order).action_confirm()
+        return True

--- a/sale_coupon_multi_use/models/sale_order.py
+++ b/sale_coupon_multi_use/models/sale_order.py
@@ -6,9 +6,27 @@ class SaleOrder(models.Model):
 
     _inherit = "sale.order"
 
+    # TODO: implement multi-use coupon relation on sale.order ->
+    # applied_coupon_ids is o2m, which removes coupon if same coupon
+    # is applied on another SO. But for multi-use coupon, it must be
+    # able to keep same coupon on multiple sale orders.
+    # TODO: action_draft seems buggy, because it does not reset back
+    # coupons to new state (you can abuse coupon this way and use normal
+    # coupon multiple times).
+
     def action_confirm(self):
-        """Extend to pass coupon_order_data context."""
+        """Extend to pass coupon_sale_order context."""
         for order in self:
             order = order.with_context(coupon_sale_order=order)
             super(SaleOrder, order).action_confirm()
+        return True
+
+    def action_cancel(self):
+        """Extend to pass coupon_sale_order context."""
+        # NOTE. Can't rely on coupon/SO relation, because
+        # applied_coupon_ids is o2m field, meaning same coupon used on
+        # another SO, would make lose relation on previous SO.
+        for order in self:
+            order = order.with_context(coupon_sale_order=order)
+            super(SaleOrder, order).action_cancel()
         return True

--- a/sale_coupon_multi_use/tests/test_sale_coupon_use.py
+++ b/sale_coupon_multi_use/tests/test_sale_coupon_use.py
@@ -189,6 +189,15 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.coupon_multi_use_1.discount_fixed_amount_delta, remaining_discount
         )
 
+    def test_05_coupon_multi_use(self):
+        """Apply multi use coupon on SO and cancel SO."""
+        self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
+        # Sanity check.
+        self.assertEqual(self.coupon_multi_use_1.state, "used")
+        self.sale_1.action_cancel()
+        self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+
     def _raise_multi_use_constraints(self, program):
         """Expect to raise exceptions when multi use coupons are used.
 

--- a/sale_coupon_multi_use/tests/test_sale_coupon_use.py
+++ b/sale_coupon_multi_use/tests/test_sale_coupon_use.py
@@ -143,6 +143,52 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         )
         self.assertEqual(self.coupon_multi_use_1.state, "new")
 
+    def test_04_coupon_multi_use(self):
+        """Apply multiple coupons and confirm SO.
+
+        Case 1: apply first coupon (single use).
+        Case 2: apply second coupon (multi use) and confirm SO.
+        """
+        # Prepare second multi use coupon from different program.
+        discount_amount_2 = 100
+        program_coupon = self.program_multi_use.copy(
+            default={
+                "discount_fixed_amount": discount_amount_2,
+                "coupon_multi_use": False,
+            }
+        )
+        self.SaleCouponGenerate.with_context(active_id=program_coupon.id).create(
+            {}
+        ).generate_coupon()
+        coupon = program_coupon.coupon_ids[0]
+        coupon_apply_wiz_2 = self.SaleCouponApplyCode.create(
+            {"coupon_code": coupon.code}
+        )
+        # Case 1.
+        amount_total_orig_1 = self.sale_2.amount_total
+        amount_total_expected = amount_total_orig_1 - discount_amount_2
+        coupon_apply_wiz_2.with_context(active_id=self.sale_2.id).process_coupon()
+        self.assertEqual(coupon.state, "used")
+        self.assertEqual(self.sale_2.amount_total, amount_total_expected)
+        consumption_line_so_2 = coupon.consumption_line_ids
+        self.assertEqual(len(consumption_line_so_2), 0)  # single use
+        # Case 2.
+        amount_total_orig_1 = self.sale_2.amount_total
+        amount_total_expected = 0
+        self.coupon_apply_wiz.with_context(active_id=self.sale_2.id).process_coupon()
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        self.sale_2.action_confirm()
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        self.assertEqual(self.sale_2.amount_total, amount_total_expected)
+        consumption_line_so_2 = self.coupon_multi_use_1.consumption_line_ids
+        self.assertEqual(len(consumption_line_so_2), 1)
+        self.assertEqual(consumption_line_so_2[0].amount, amount_total_orig_1)
+        remaining_discount = DISCOUNT_AMOUNT - amount_total_orig_1
+        # Delta showing left amount that can be consumed.
+        self.assertEqual(
+            self.coupon_multi_use_1.discount_fixed_amount_delta, remaining_discount
+        )
+
     def _raise_multi_use_constraints(self, program):
         """Expect to raise exceptions when multi use coupons are used.
 
@@ -184,12 +230,12 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
                 "coupon_multi_use=False and no multi_use coupons generated."
             )
 
-    def test_04_unlink_consumption_line(self):
+    def test_05_unlink_consumption_line(self):
         """Check if consumption line not allowed to unlink."""
         with self.assertRaises(UserError):
             self.coupon_multi_use_1.consumption_line_ids.unlink()
 
-    def test_05_coupon_program_constraints(self):
+    def test_06_coupon_program_constraints(self):
         """Check coupon constraints when multi use coupon is generated.
 
         Case 1: multi_use=True
@@ -204,7 +250,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.program_multi_use.discount_fixed_amount = 3000
         self._raise_multi_use_constraints(self.program_multi_use)
 
-    def test_06_coupon_program_constraints(self):
+    def test_07_coupon_program_constraints(self):
         """Check constraints when multi use coupon is not generated.
 
         Case 1: multi_use=True
@@ -231,7 +277,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         pass_discount_fixed_amount(program)
         self._not_raise_multi_use_constraints(program)
 
-    def test_07_coupon_program_constraints(self):
+    def test_08_coupon_program_constraints(self):
         """Try to use coupon_multi_use, when other options are incorrect."""
         with self.assertRaises(ValidationError):
             self.program_coupon_percentage.coupon_multi_use = True

--- a/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
+++ b/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
@@ -1,3 +1,5 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 
 

--- a/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
+++ b/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
@@ -10,12 +10,5 @@ class SaleCouponApplyCode(models.TransientModel):
 
     def apply_coupon(self, order, coupon_code):
         """Extend to pass order coupon ctx for multi coupon usage."""
-        self = self.with_context(
-            coupon_order_data={
-                "order": order,
-                # To save original amount, before any discounts are
-                # applied.
-                "amount_total": order.amount_total,
-            }
-        )
+        self = self.with_context(coupon_sale_order=order, coupon_code=coupon_code)
         return super(SaleCouponApplyCode, self).apply_coupon(order, coupon_code)


### PR DESCRIPTION
[FIX] sale_coupon_multi_use: sale confirm

Coupons are marked as consumed twice. First time when coupon is added
and second when sale order is confirmed.

For that, multi-use coupon must not be marked as consumed when
confirming order (if it is still valid by multi-use rules).

Also had to redesign the way multi use coupons are checked on write,
because during confirmation it can update multiple coupons and old
implementation was able to handle one coupon at a time.

On top of that, simplified multi-use coupon handling. Now correct amount
is intercepted when discount_fixed_amount is computed for reward line.

This gives multiple advantages:
    - no need to adjust sale order line discount afterwards.
    - _compute_program_amount handles currency conversion, so multi-use
        consumed amount now also takes care of that too.
    - simpler consumption line creation and checking if coupon is fully
        consumed (no need to compare delta with discount that would need
        to be computed from sale order).
