### PR TITLE
[IMP] sale_coupon_product_management: program vals

### DIFF
--- a/sale_coupon_product_management/models/product_product.py
+++ b/sale_coupon_product_management/models/product_product.py
@@ -16,11 +16,10 @@ class ProductProduct(models.Model):
 
     @api.onchange("categ_id")
     def _onchange_product_categ_with_opts(self):
-        if self._predicate_product_categ_with_opts():
+        if self.categ_id._predicate_product_categ_with_opts():
             # Updating only product.product values here.
-            self.update(
-                self.program_option_ids.get_program_values()[DISCOUNT_PRODUCT_FNAME]
-            )
+            options = self.categ_id.program_option_ids
+            self.update(options.get_program_values()[DISCOUNT_PRODUCT_FNAME])
 
     @api.constrains("categ_id", "sale_ok")
     def _check_product_options(self):

--- a/sale_coupon_product_management/models/sale_coupon_program_option.py
+++ b/sale_coupon_product_management/models/sale_coupon_program_option.py
@@ -42,7 +42,7 @@ class SaleCouponProgramOption(models.Model):
 
     @api.model
     def _get_program_values_template(self):
-        return {SELF: {}, "discount_line_product_id": {}}  # sale.coupon.program
+        return {SELF: {}, DISCOUNT_PRODUCT_FNAME: {}}  # sale.coupon.program
 
     @api.model
     def _get_program_values_cfg(self):
@@ -98,7 +98,14 @@ class SaleCouponProgramOption(models.Model):
             return program
         return operator.attrgetter(path)(program)
 
-    def get_program_values(self):
+    def _update_values_from_program(self, opt_vals, program=None):
+        self.ensure_one()
+        if program and self.option_type == "discount_fixed_amount":
+            opt_vals[DISCOUNT_PRODUCT_FNAME][
+                "list_price"
+            ] = program.discount_fixed_amount
+
+    def get_program_values(self, program=None):
         """Return program values from related options.
 
         Values returned are for program and related product.
@@ -114,6 +121,7 @@ class SaleCouponProgramOption(models.Model):
         for option in self:
             opt_cfg = cfg[option.option_type]
             opt_vals = opt_cfg["values"]
+            option._update_values_from_program(opt_vals, program=program)
             opt_keys = opt_vals.keys()
             for key in opt_keys:
                 values[key].update(opt_vals[key])

--- a/sale_coupon_product_management/models/sale_coupon_program_option.py
+++ b/sale_coupon_product_management/models/sale_coupon_program_option.py
@@ -98,9 +98,9 @@ class SaleCouponProgramOption(models.Model):
             return program
         return operator.attrgetter(path)(program)
 
-    def _update_values_from_program(self, opt_vals, program=None):
+    def _update_values_from_program(self, opt_vals, program):
         self.ensure_one()
-        if program and self.option_type == "discount_fixed_amount":
+        if self.option_type == "discount_fixed_amount":
             opt_vals[DISCOUNT_PRODUCT_FNAME][
                 "list_price"
             ] = program.discount_fixed_amount
@@ -121,7 +121,8 @@ class SaleCouponProgramOption(models.Model):
         for option in self:
             opt_cfg = cfg[option.option_type]
             opt_vals = opt_cfg["values"]
-            option._update_values_from_program(opt_vals, program=program)
+            if program:  # TODO: a bit redundant.
+                option._update_values_from_program(opt_vals, program)
             opt_keys = opt_vals.keys()
             for key in opt_keys:
                 values[key].update(opt_vals[key])

--- a/sale_coupon_product_management/models/sale_coupon_program_option.py
+++ b/sale_coupon_product_management/models/sale_coupon_program_option.py
@@ -120,12 +120,7 @@ class SaleCouponProgramOption(models.Model):
         for option in self:
             opt_cfg = cfg[option.option_type]
             opt_vals = opt_cfg["values"]
-            if program:  # TODO: a bit redundant.
-                # NOTE. This is bad design. If values from program would
-                # need to include extra values on different level dicts,
-                # this could easily break or work incorrectly. Its
-                # because get_program_values needs to be aware what
-                # _prepare_values_from_program needs to return.
+            if program:
                 opt_vals[DISCOUNT_PRODUCT_FNAME].update(
                     option._prepare_values_from_program(program)
                 )

--- a/sale_coupon_product_management/tests/common.py
+++ b/sale_coupon_product_management/tests/common.py
@@ -7,6 +7,8 @@ from odoo.tests.common import SavepointCase
 OPTION_XMLID_PREFIX = (
     "sale_coupon_product_management.sale_coupon_program_option_coupon_"
 )
+NAME_COUPON_PROGRAM = "Dummy Coupon Program"
+CODE_COUPON_PROGRAM = "MYCODE123"
 
 
 class TestSaleCouponProductManageCommon(SavepointCase):
@@ -40,3 +42,20 @@ class TestSaleCouponProductManageCommon(SavepointCase):
         cls.sale_1 = cls.env.ref("sale.sale_order_1")
         # amount_total = 2947.5
         cls.sale_2 = cls.env.ref("sale.sale_order_2")
+        cls.product_category_promotion = cls.ProductCategory.create(
+            {"name": "Dummy Promotion Category", "is_promotion_category": True}
+        )
+        cls.product_category_coupon = cls.ProductCategory.create(
+            {"name": "Dummy Coupon Category", "is_coupon_category": True}
+        )
+        cls.program_coupon_1 = cls.SaleCouponProgram.create(
+            {
+                "name": NAME_COUPON_PROGRAM,
+                "program_type": "coupon_program",
+                "reward_type": "discount",
+                "discount_type": "fixed_amount",
+                "discount_fixed_amount": 1000,
+                "related_product_default_code": CODE_COUPON_PROGRAM,
+                "related_product_categ_id": cls.product_category_coupon.id,
+            }
+        )

--- a/sale_coupon_product_management/tests/test_sale_coupon_manage.py
+++ b/sale_coupon_product_management/tests/test_sale_coupon_manage.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests.common import Form
 
 from .common import (
     CODE_COUPON_PROGRAM,
@@ -209,3 +210,17 @@ class TestSaleCouponManage(TestSaleCouponProductManageCommon):
             self.product_category_promotion.copy(
                 default={"default_promotion_next_order_category": True}
             )
+
+    def test_08_onchange_product_categ_with_opts(self):
+        """Onchange product category that has program option."""
+        product = self.program_coupon_1.discount_line_product_id
+        self.assertFalse(product.sale_ok)
+        self.product_category_coupon.program_option_ids = [
+            (4, self.program_option_sale_ok.id)
+        ]
+        # Need to use Form, so constraint is not triggered before
+        # onchange.
+        with Form(product) as p:
+            p.categ_id = self.product_category_coupon
+            # product._onchange_product_categ_with_opts()
+            self.assertTrue(p.sale_ok)

--- a/sale_coupon_product_management/tests/test_sale_coupon_manage.py
+++ b/sale_coupon_product_management/tests/test_sale_coupon_manage.py
@@ -2,36 +2,15 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError, ValidationError
 
-from .common import TestSaleCouponProductManageCommon
-
-NAME_COUPON_PROGRAM = "Dummy Coupon Program"
-CODE_COUPON_PROGRAM = "MYCODE123"
+from .common import (
+    CODE_COUPON_PROGRAM,
+    NAME_COUPON_PROGRAM,
+    TestSaleCouponProductManageCommon,
+)
 
 
 class TestSaleCouponManage(TestSaleCouponProductManageCommon):
     """Test class for program management use cases."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Set up data for multi use coupon tests."""
-        super().setUpClass()
-        cls.product_category_promotion = cls.ProductCategory.create(
-            {"name": "Dummy Promotion Category", "is_promotion_category": True}
-        )
-        cls.product_category_coupon = cls.ProductCategory.create(
-            {"name": "Dummy Coupon Category", "is_coupon_category": True}
-        )
-        cls.program_coupon_1 = cls.SaleCouponProgram.create(
-            {
-                "name": NAME_COUPON_PROGRAM,
-                "program_type": "coupon_program",
-                "reward_type": "discount",
-                "discount_type": "fixed_amount",
-                "discount_fixed_amount": 1000,
-                "related_product_default_code": CODE_COUPON_PROGRAM,
-                "related_product_categ_id": cls.product_category_coupon.id,
-            }
-        )
 
     def test_01_program_discount_product_rel_vals(self):
         """Check created program with related product.

--- a/sale_coupon_product_management/tests/test_sale_coupon_options.py
+++ b/sale_coupon_product_management/tests/test_sale_coupon_options.py
@@ -33,6 +33,7 @@ class TestSaleCouponOptions(TestSaleCouponProductManageCommon):
 
         Case 1: discount_fixed_amount + product_sale_ok
         Case 2: discount_fixed_amount + product_not_sale_ok
+        Case 3: discount_fixed_amount (with program rec) + product_not_sale_ok
         """
         # Case 1.
         values = (
@@ -54,6 +55,20 @@ class TestSaleCouponOptions(TestSaleCouponProductManageCommon):
             {
                 SELF: {"reward_type": "discount", "discount_type": "fixed_amount"},
                 DISCOUNT_PRODUCT_FNAME: {"sale_ok": False},
+            },
+        )
+        # Case 3.
+        values = (
+            self.program_option_fixed_amount | self.program_option_not_sale_ok
+        ).get_program_values(program=self.program_coupon_1)
+        self.assertEqual(
+            values,
+            {
+                SELF: {"reward_type": "discount", "discount_type": "fixed_amount"},
+                DISCOUNT_PRODUCT_FNAME: {
+                    "sale_ok": False,
+                    "list_price": self.program_coupon_1.discount_fixed_amount,
+                },
             },
         )
 


### PR DESCRIPTION
Now program/product values generated from options can use optional
`program` record, so it could access dynamic values (in this case for
related product).