### PR TITLE
[IMP] sale_coupon_multi_use: m2m relation

### DIFF
--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -23,7 +23,7 @@ msgstr "Montant"
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__sale_multi_use_ids
 msgid "Applied on Orders"
-msgstr ""
+msgstr "Appliqué sur les bons de commandes"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__consumption_line_ids
@@ -125,7 +125,7 @@ msgstr ""
 #: code:addons/sale_coupon_multi_use/models/sale_coupon.py:0
 #, python-format
 msgid "Multi-Use Coupon is already applied for the same reward"
-msgstr ""
+msgstr "Le coupon a déjà été appliqué sur la même récompense"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_consumption_line
@@ -145,7 +145,7 @@ msgstr "Bons de réduction"
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_apply_code
 msgid "Sales Coupon Apply Code"
-msgstr "Codice di applicazione coupon di vendita"
+msgstr "Code du bon de réduction"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_program

--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-25 14:46+0000\n"
-"PO-Revision-Date: 2020-11-25 14:46+0000\n"
+"POT-Creation-Date: 2020-12-03 12:46+0000\n"
+"PO-Revision-Date: 2020-12-03 12:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,6 +19,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__amount
 msgid "Amount"
 msgstr "Montant"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__sale_multi_use_ids
+msgid "Applied on Orders"
+msgstr ""
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__consumption_line_ids
@@ -103,6 +108,7 @@ msgstr "Sécable"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_program__coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_order__coupon_multi_use_ids
 msgid "Multi Use Coupons"
 msgstr "Bon de réduction sécable"
 
@@ -114,6 +120,12 @@ msgid ""
 " Fixed Amount as Apply Discount"
 msgstr ""
 "Les bons de réductions sécables doivent être de type Remise et Montant fixe"
+
+#. module: sale_coupon_multi_use
+#: code:addons/sale_coupon_multi_use/models/sale_coupon.py:0
+#, python-format
+msgid "Multi-Use Coupon is already applied for the same reward"
+msgstr ""
 
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_consumption_line
@@ -133,7 +145,7 @@ msgstr "Bons de réduction"
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_apply_code
 msgid "Sales Coupon Apply Code"
-msgstr "Code du bon de réduction"
+msgstr "Codice di applicazione coupon di vendita"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_program
@@ -144,3 +156,8 @@ msgstr "Campagne de bons de réduction"
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_order
 msgid "Sales Order"
 msgstr "Bon de commande"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model,name:sale_coupon_multi_use.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Ligne de bons de commande"

--- a/sale_coupon_multi_use/models/sale_coupon.py
+++ b/sale_coupon_multi_use/models/sale_coupon.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import pickle
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 def _pickle_copy(data):
@@ -28,6 +28,15 @@ class SaleCoupon(models.Model):
         compute="_compute_discount_fixed_amount_delta",
         currency_field="currency_program_id",
     )
+    sale_multi_use_ids = fields.Many2many(
+        "sale.order",
+        "sale_order_coupon_multi_rel",
+        "coupon_id",
+        "sale_id",
+        string="Applied on Orders",
+        copy=False,
+        readonly=True,
+    )
 
     def _get_discount_fixed_amount_delta(self):
         self.ensure_one()
@@ -39,6 +48,14 @@ class SaleCoupon(models.Model):
     def _compute_discount_fixed_amount_delta(self):
         for rec in self:
             rec.discount_fixed_amount_delta = rec._get_discount_fixed_amount_delta()
+
+    def _check_coupon_code(self, order):
+        # Same check as is for `applied_coupon_ids` field.
+        if self.program_id in order.coupon_multi_use_ids.mapped("program_id"):
+            return {
+                "error": _("Multi-Use Coupon is already applied for the same reward")
+            }
+        return super()._check_coupon_code(order)
 
     def _filter_multi_use_triggered(self, vals):
         # Indicating for coupon to be consumed
@@ -113,14 +130,14 @@ class SaleCoupon(models.Model):
         """Extend to manage multi_use coupons.
 
         Each coupon record is handled separately, because some might
-        be valid, some not after handling multi use.
+        be valid, some not, after handling multi use.
         """
         coupon_sale_order = self._context.get("coupon_sale_order")
         other_coupons = self  # by default all coupons.
         if coupon_sale_order:
-            multi_use_coupons = self._filter_multi_use_triggered(vals)
-            other_coupons = self - multi_use_coupons
-            for multi_use_coupon in multi_use_coupons:
+            coupon_multi_use = self._filter_multi_use_triggered(vals)
+            other_coupons = self - coupon_multi_use
+            for multi_use_coupon in coupon_multi_use:
                 copied_vals = _pickle_copy(vals)
                 coupon_still_valid = multi_use_coupon._handle_multi_use(
                     coupon_sale_order

--- a/sale_coupon_multi_use/models/sale_coupon.py
+++ b/sale_coupon_multi_use/models/sale_coupon.py
@@ -51,7 +51,7 @@ class SaleCoupon(models.Model):
 
     def _check_coupon_code(self, order):
         # Same check as is for `applied_coupon_ids` field.
-        if self.program_id in order.coupon_multi_use_ids.mapped("program_id"):
+        if self.program_id in order.mapped("coupon_multi_use_ids.program_id"):
             return {
                 "error": _("Multi-Use Coupon is already applied for the same reward")
             }
@@ -152,3 +152,14 @@ class SaleCoupon(models.Model):
             if vals.get("state") == "new":
                 self._handle_multi_use_reset(coupon_sale_order)
         return super(SaleCoupon, other_coupons).write(vals)
+
+    # NOTE. This is a bit limited. Such methods should be defined on
+    # sale_coupon, because its related with all coupons, not just
+    # multi-use coupons.
+    def consume_coupons(self):
+        """Set coupons state to 'used'."""
+        self.write({"state": "used"})
+
+    def reset_coupons(self):
+        """Set coupons state to 'new'."""
+        self.write({"state": "new"})

--- a/sale_coupon_multi_use/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use/models/sale_coupon_program.py
@@ -61,11 +61,11 @@ class SaleCouponProgram(models.Model):
                 )
 
     def _compute_program_multi_use_amount(
-        self, multi_use_coupon, sale_order, currency_to
+        self, coupon_multi_use, sale_order, currency_to
     ):
         # Only using remaining amount (original implementation
         # always uses full amount specified on related program).
-        amount_delta = multi_use_coupon.discount_fixed_amount_delta
+        amount_delta = coupon_multi_use.discount_fixed_amount_delta
         amount_delta = self.currency_id._convert(
             amount_delta, currency_to, self.company_id, fields.Date.today()
         )
@@ -77,7 +77,7 @@ class SaleCouponProgram(models.Model):
         coupon_code = self._context.get("coupon_code")
         sale_order = self._context.get("coupon_sale_order")
         if coupon_code and sale_order and field == "discount_fixed_amount":
-            multi_use_coupon = self.env["sale.coupon"].search(
+            coupon_multi_use = self.env["sale.coupon"].search(
                 [
                     ("multi_use", "=", True),
                     ("code", "=", coupon_code),
@@ -85,9 +85,9 @@ class SaleCouponProgram(models.Model):
                 ],
                 limit=1,
             )
-            if multi_use_coupon:
+            if coupon_multi_use:
                 return self._compute_program_multi_use_amount(
-                    multi_use_coupon, sale_order, currency_to
+                    coupon_multi_use, sale_order, currency_to
                 )
 
         return super()._compute_program_amount(field, currency_to)

--- a/sale_coupon_multi_use/models/sale_order.py
+++ b/sale_coupon_multi_use/models/sale_order.py
@@ -1,4 +1,10 @@
-from odoo import models
+from odoo import fields, models
+
+ORDER_CTX_KEY = "coupon_sale_order"
+
+
+def _get_order_line_coupons_filter(line):
+    return lambda r: r.program_id.discount_line_product_id == line.product_id
 
 
 class SaleOrder(models.Model):
@@ -6,27 +12,123 @@ class SaleOrder(models.Model):
 
     _inherit = "sale.order"
 
-    # TODO: implement multi-use coupon relation on sale.order ->
-    # applied_coupon_ids is o2m, which removes coupon if same coupon
-    # is applied on another SO. But for multi-use coupon, it must be
-    # able to keep same coupon on multiple sale orders.
-    # TODO: action_draft seems buggy, because it does not reset back
-    # coupons to new state (you can abuse coupon this way and use normal
-    # coupon multiple times).
+    coupon_multi_use_ids = fields.Many2many(
+        "sale.coupon",
+        "sale_order_coupon_multi_rel",
+        "sale_id",
+        "coupon_id",
+        string="Multi Use Coupons",
+        copy=False,
+        readonly=True,
+    )
+
+    def _get_multi_use_coupons_to_handle(self, filter_func=None):
+        self.ensure_one()
+        coupons = self.coupon_multi_use_ids - self.applied_coupon_ids
+        if filter_func:
+            return filter_func(coupons)
+        return coupons
+
+    def _trigger_multi_use_coupons(self, state, filter_func=None):
+        self.ensure_one()
+        # NOTE. This method must be called with ORDER_CTX_KEY on order.
+        multi_use_coupons = self._get_multi_use_coupons_to_handle()
+        if multi_use_coupons:
+            multi_use_coupons.write({"state": state})
+        return multi_use_coupons
 
     def action_confirm(self):
         """Extend to pass coupon_sale_order context."""
         for order in self:
-            order = order.with_context(coupon_sale_order=order)
+            # Mimic same behavior as for single-user coupon.
+            order = order.with_context(**{ORDER_CTX_KEY: order})
             super(SaleOrder, order).action_confirm()
+            order._trigger_multi_use_coupons("used")
         return True
 
     def action_cancel(self):
         """Extend to pass coupon_sale_order context."""
-        # NOTE. Can't rely on coupon/SO relation, because
-        # applied_coupon_ids is o2m field, meaning same coupon used on
-        # another SO, would make lose relation on previous SO.
         for order in self:
-            order = order.with_context(coupon_sale_order=order)
+            order = order = order.with_context(**{ORDER_CTX_KEY: order})
             super(SaleOrder, order).action_cancel()
+            order._trigger_multi_use_coupons("new")
         return True
+
+    def action_draft(self):
+        """Extend to pass coupon_sale_order context."""
+        super().action_draft()
+        for order in self:
+            # TODO: refactor this to use same approach as for
+            # action_confirm and action_cancel if Odoo fixes their bug.
+            # Now single use coupons are not reset back if you put SO to
+            # draft state.
+            coupons_multi_use = order.coupon_multi_use_ids
+            if coupons_multi_use:
+                coupons_multi_use.with_context(**{ORDER_CTX_KEY: order}).write(
+                    {"state": "used"}
+                )
+        return True
+
+    def _get_coupons_from_2many_commands(self, commands):
+        ids = []
+        for cmd in commands:
+            if cmd[0] == 6:
+                ids.extend(cmd[2])
+            elif cmd[0] == 4:
+                ids.append(cmd[1])
+        return self.env["sale.coupon"].browse(ids)
+
+    def _get_multi_use_coupons_from_2many_commands(self, commands):
+        coupons = self._get_coupons_from_2many_commands(commands)
+        return coupons.filtered("multi_use")
+
+    def write(self, vals):
+        """Extend to add multi-use coupons."""
+        if vals.get("applied_coupon_ids"):
+            coupons_multi_use = self._get_multi_use_coupons_from_2many_commands(
+                vals["applied_coupon_ids"]
+            )
+            if coupons_multi_use:
+                vals["coupon_multi_use_ids"] = [(6, 0, coupons_multi_use.ids)]
+        return super().write(vals)
+
+
+class SaleOrderLine(models.Model):
+    """Extend to reverse relate with consumption line."""
+
+    _inherit = "sale.order.line"
+
+    def unlink(self):
+        """Extend to reactivate/reset removed multi-use coupons."""
+        related_program_lines = self.env["sale.order.line"]
+        # Reactivate coupons related to unlinked reward line
+        for line in self.filtered(lambda line: line.is_reward_line):
+            order = line.order_id
+            _filter = _get_order_line_coupons_filter(line)
+            coupons_to_detach = order.coupon_multi_use_ids.filtered(_filter)
+            # We can only reactivate coupons that are not part of
+            # applied_coupon_ids, because that part will signal
+            # reactivate too.
+            coupons_to_reactivate = (
+                coupons_to_detach - order.applied_coupon_ids.filtered(_filter)
+            )
+            coupons_to_reactivate.write({"state": "new"})
+            order.coupon_multi_use_ids -= coupons_to_detach
+            # Remove the program from the order if the deleted line is
+            # the reward line of the program.
+            # And delete the other lines from this program (It's the
+            # case when discount is split per different taxes)
+            related_program = self.env["sale.coupon.program"].search(
+                [("discount_line_product_id", "=", line.product_id.id)]
+            )
+            if related_program:
+                # No need to remove promotions, because multi-use
+                # coupons are not related with promotions.
+                related_program_lines |= (
+                    order.order_line.filtered(
+                        lambda l: l.product_id
+                        == related_program.discount_line_product_id
+                    )
+                    - line
+                )
+        return super(SaleOrderLine, self | related_program_lines).unlink()

--- a/sale_coupon_multi_use/models/sale_order.py
+++ b/sale_coupon_multi_use/models/sale_order.py
@@ -42,18 +42,8 @@ class SaleOrder(models.Model):
             order = order = order.with_context(**{ORDER_CTX_KEY: order})
             super(SaleOrder, order).action_cancel()
             order._get_multi_use_coupons().reset_coupons()
-        return True
-
-    def action_draft(self):
-        """Extend to pass coupon_sale_order context."""
-        super().action_draft()
-        for order in self:
-            order = order = order.with_context(**{ORDER_CTX_KEY: order})
-            # TODO: refactor this to use same approach as for
-            # action_confirm and action_cancel if Odoo fixes their bug.
-            # Now single use coupons are not reset back if you put SO to
-            # draft state.
-            order.coupon_multi_use_ids.consume_coupons()
+            # Mimic applied_coupon_ids logic.
+            order.coupon_multi_use_ids = [(5,)]
         return True
 
     def _get_coupons_from_2many_commands(self, commands):

--- a/sale_coupon_multi_use/tests/test_sale_coupon_use.py
+++ b/sale_coupon_multi_use/tests/test_sale_coupon_use.py
@@ -20,6 +20,11 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
                 pricelist.currency_id = self.eur
         return pricelist.currency_id, company.currency_id
 
+    def _cmp_record_ids(self, rec1, rec2):
+        self.assertEqual(
+            sorted(rec1.ids), sorted(rec2.ids), "{} not equal to {}".format(rec1, rec2)
+        )
+
     def _remove_so_discount_lines(self, order):
         order.order_line.filtered(lambda r: r.price_unit < 0).unlink()
 
@@ -38,6 +43,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         # Sanity check.
         self.assertEqual(self.sale_1.amount_total, amount_total_expected)
         self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
+        self.assertFalse(self.sale_1.coupon_multi_use_ids)
 
     def test_02_coupon_multi_use(self):
         """Apply coupon to consume all amount in one use.
@@ -57,6 +63,8 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         self.assertEqual(consume_lines[0].amount, DISCOUNT_AMOUNT)
         self.assertEqual(self.coupon_multi_use_1.discount_fixed_amount_delta, 0)
         self.assertEqual(self.coupon_multi_use_1.state, "used")
+        # Check if multi-coupons were applied.
+        self.assertEqual(self.sale_1.coupon_multi_use_ids, self.coupon_multi_use_1)
         # Case 2.
         with self.assertRaises(UserError):
             self.coupon_apply_wiz.with_context(
@@ -93,6 +101,9 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.coupon_multi_use_1.discount_fixed_amount_delta, remaining_discount
         )
         self.assertEqual(self.coupon_multi_use_1.state, "new")
+        # Check if multi-coupons were applied.
+        self.assertEqual(self.sale_2.coupon_multi_use_ids, self.coupon_multi_use_1)
+        self.assertEqual(self.coupon_multi_use_1.sale_multi_use_ids, self.sale_2)
         # Case 2.
         amount_total_expected = self.sale_1.amount_total - remaining_discount
         self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
@@ -105,6 +116,12 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         self.assertEqual(consume_lines[1].amount, remaining_discount)
         self.assertEqual(self.coupon_multi_use_1.discount_fixed_amount_delta, 0)
         self.assertEqual(self.coupon_multi_use_1.state, "used")
+        # Check if another SO was related with multi use coupon.
+        self.assertEqual(self.sale_2.coupon_multi_use_ids, self.coupon_multi_use_1)
+        self.assertEqual(self.sale_1.coupon_multi_use_ids, self.coupon_multi_use_1)
+        self._cmp_record_ids(
+            self.coupon_multi_use_1.sale_multi_use_ids, self.sale_1 | self.sale_2
+        )
         # Case 3.
         self._remove_so_discount_lines(self.sale_1)
         consume_lines = self.coupon_multi_use_1.consumption_line_ids
@@ -120,6 +137,10 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.coupon_multi_use_1.discount_fixed_amount_delta, remaining_discount
         )
         self.assertEqual(self.coupon_multi_use_1.state, "new")
+        # Check if coupon was removed following removed SO line.
+        self.assertEqual(self.sale_2.coupon_multi_use_ids, self.coupon_multi_use_1)
+        self.assertFalse(self.sale_1.coupon_multi_use_ids)
+        self.assertEqual(self.coupon_multi_use_1.sale_multi_use_ids, self.sale_2)
         # Case 4.
         self._remove_so_discount_lines(self.sale_2)
         self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
@@ -127,6 +148,9 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.coupon_multi_use_1.discount_fixed_amount_delta, DISCOUNT_AMOUNT
         )
         self.assertEqual(self.coupon_multi_use_1.state, "new")
+        # Check if both SO are now unrelated with multi-use coupon.
+        self.assertFalse(self.sale_1.coupon_multi_use_ids)
+        self.assertFalse(self.sale_2.coupon_multi_use_ids)
 
     def test_04_coupon_multi_use(self):
         """Apply multi use coupon on SO with different currency.
@@ -222,13 +246,49 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         )
 
     def test_06_coupon_multi_use(self):
-        """Apply multi use coupon on SO and cancel SO."""
+        """Apply multi-use coupons, then cancel/draft/confirm SOs.
+
+        Case 1: cancel sale orders.
+        Case 2: set draft sale orders.
+        Case 3: confirm sale orders.
+        """
+        self.coupon_apply_wiz.with_context(active_id=self.sale_2.id).process_coupon()
         self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
-        # Sanity check.
+        # Case 1.
         self.assertEqual(self.coupon_multi_use_1.state, "used")
+        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 2)
+        self.sale_2.action_cancel()
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 1)
         self.sale_1.action_cancel()
         self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
         self.assertEqual(self.coupon_multi_use_1.state, "new")
+        # Case 2.
+        self.sale_2.action_draft()
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 1)
+        self.sale_1.action_draft()
+        self.assertEqual(self.coupon_multi_use_1.state, "used")
+        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 2)
+        # Case 3.
+        (self.sale_1 | self.sale_2).action_confirm()
+        self.assertEqual(self.coupon_multi_use_1.state, "used")
+        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 2)
+
+    def test_07_coupon_multi_use(self):
+        """Try to use different multi-use coupons from same program."""
+        self.coupon_generate_wiz.generate_coupon()
+        coupon_multi_use_2 = self.program_multi_use.coupon_ids[-1]
+        # Apply first coupon
+        self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
+        # Imitate case when applied_coupon_ids is cleared by other SO.
+        self.sale_2.applied_coupon_ids = [(4, self.coupon_multi_use_1.id)]
+        # Try to apply second coupon from same program.
+        with self.assertRaises(UserError):
+            self.coupon_apply_wiz.coupon_code = coupon_multi_use_2.code
+            self.coupon_apply_wiz.with_context(
+                active_id=self.sale_1.id
+            ).process_coupon()
 
     def _raise_multi_use_constraints(self, program):
         """Expect to raise exceptions when multi use coupons are used.
@@ -271,12 +331,12 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
                 "coupon_multi_use=False and no multi_use coupons generated."
             )
 
-    def test_07_unlink_consumption_line(self):
+    def test_08_unlink_consumption_line(self):
         """Check if consumption line not allowed to unlink."""
         with self.assertRaises(UserError):
             self.coupon_multi_use_1.consumption_line_ids.unlink()
 
-    def test_08_coupon_program_constraints(self):
+    def test_09_coupon_program_constraints(self):
         """Check coupon constraints when multi use coupon is generated.
 
         Case: multi_use=True
@@ -285,7 +345,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.program_multi_use.discount_fixed_amount = 3000
         self._raise_multi_use_constraints(self.program_multi_use)
 
-    def test_09_coupon_program_constraints(self):
+    def test_10_coupon_program_constraints(self):
         """Check coupon constraints when multi use coupon is generated.
 
         Case: multi_use=False
@@ -295,7 +355,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.program_multi_use.discount_fixed_amount = 3000
         self._raise_multi_use_constraints(self.program_multi_use)
 
-    def test_10_coupon_program_constraints(self):
+    def test_11_coupon_program_constraints(self):
         """Check constraints when multi use coupon is not generated.
 
         Case 1: multi_use=True
@@ -322,7 +382,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         pass_discount_fixed_amount(program)
         self._not_raise_multi_use_constraints(program)
 
-    def test_11_coupon_program_constraints(self):
+    def test_12_coupon_program_constraints(self):
         """Try to use coupon_multi_use, when other options are incorrect."""
         with self.assertRaises(ValidationError):
             self.program_coupon_percentage.coupon_multi_use = True

--- a/sale_coupon_multi_use/tests/test_sale_coupon_use.py
+++ b/sale_coupon_multi_use/tests/test_sale_coupon_use.py
@@ -250,7 +250,6 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
 
         Case 1: cancel sale orders.
         Case 2: set draft sale orders.
-        Case 3: confirm sale orders.
         """
         self.coupon_apply_wiz.with_context(active_id=self.sale_2.id).process_coupon()
         self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
@@ -258,22 +257,23 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         self.assertEqual(self.coupon_multi_use_1.state, "used")
         self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 2)
         self.sale_2.action_cancel()
+        self.assertFalse(self.sale_2.coupon_multi_use_ids)
         self.assertEqual(self.coupon_multi_use_1.state, "new")
         self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 1)
         self.sale_1.action_cancel()
+        self.assertFalse(self.sale_1.coupon_multi_use_ids)
         self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
         self.assertEqual(self.coupon_multi_use_1.state, "new")
         # Case 2.
         self.sale_2.action_draft()
+        self.assertFalse(self.sale_2.coupon_multi_use_ids)
         self.assertEqual(self.coupon_multi_use_1.state, "new")
-        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 1)
+        self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
         self.sale_1.action_draft()
-        self.assertEqual(self.coupon_multi_use_1.state, "used")
-        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 2)
-        # Case 3.
-        (self.sale_1 | self.sale_2).action_confirm()
-        self.assertEqual(self.coupon_multi_use_1.state, "used")
-        self.assertEqual(len(self.coupon_multi_use_1.consumption_line_ids), 2)
+        self.assertFalse(self.sale_1.coupon_multi_use_ids)
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
+        self.assertFalse(self.sale_1.coupon_multi_use_ids)
 
     def test_07_coupon_multi_use(self):
         """Try to use different multi-use coupons from same program."""

--- a/sale_coupon_multi_use/views/sale_coupon_views.xml
+++ b/sale_coupon_multi_use/views/sale_coupon_views.xml
@@ -19,6 +19,13 @@
                 <field name="currency_program_id" invisible="1" />
                 <field name="multi_use" />
             </field>
+            <field name="sales_order_id" position="after">
+                <field
+                    name="sale_multi_use_ids"
+                    widget="many2many_tags"
+                    attrs="{'invisible': [('multi_use', '=', False)]}"
+                />
+            </field>
             <xpath expr="/form/sheet/group" position="after">
                 <field
                     name="consumption_line_ids"


### PR DESCRIPTION
`coupon_multi_use_ids` on sale.order is now used to track multi-use
coupons on sale orders. `applied_coupon_ids` field did not suit multi-use
coupons case, because it is o2m field where if same coupon is applied
on next sale order, its relation with old sale order is removed.

This relation follows similar logis as is for `applied_coupon_ids` field
relation logic.