### PR TITLE
[FIX] sale_coupon_advanced_delivery: init

### DIFF
--- a/sale_coupon_advanced/models/sale_order.py
+++ b/sale_coupon_advanced/models/sale_order.py
@@ -137,9 +137,17 @@ class SaleOrder(models.Model):
         new_sale_order.onchange_partner_id()
         self._update_pricelist(new_sale_order.pricelist_id)
 
+    def get_update_pricelist_order_lines(self):
+        """Return order lines to trigger product_id_change method.
+
+        Can be extended to filter returned lines.
+        """
+        self.ensure_one()
+        return self.order_line
+
     def _update_pricelist(self, pricelist):
         self.pricelist_id = pricelist
-        for line in self.order_line:
+        for line in self.get_update_pricelist_order_lines():
             line.product_id_change()
 
     # FIXME: find simpler solution, so write/unlink would not

--- a/sale_coupon_advanced_delivery/__init__.py
+++ b/sale_coupon_advanced_delivery/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_coupon_advanced_delivery/__manifest__.py
+++ b/sale_coupon_advanced_delivery/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Sale Coupon Advanced Programs with Delivery",
+    "summary": "Bridge sale coupon advanced with delivery module",
+    "version": "13.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["sale_coupon_advanced", "delivery"],
+    "installable": True,
+    "auto_install": True,
+}

--- a/sale_coupon_advanced_delivery/__manifest__.py
+++ b/sale_coupon_advanced_delivery/__manifest__.py
@@ -8,7 +8,7 @@
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["sale_coupon_advanced", "delivery"],
+    "depends": ["sale_coupon_advanced", "sale_coupon_delivery"],
     "installable": True,
     "auto_install": True,
 }

--- a/sale_coupon_advanced_delivery/models/__init__.py
+++ b/sale_coupon_advanced_delivery/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_coupon_advanced_delivery/models/sale_order.py
+++ b/sale_coupon_advanced_delivery/models/sale_order.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    """Extend to make promotions recompute aware of delivery lines."""
+
+    _inherit = "sale.order"
+
+    def get_update_pricelist_order_lines(self):
+        """Extend to ignore delivery lines."""
+        order_lines = super().get_update_pricelist_order_lines()
+        return order_lines.filtered(lambda r: not r.is_delivery)

--- a/sale_coupon_advanced_delivery/models/sale_order.py
+++ b/sale_coupon_advanced_delivery/models/sale_order.py
@@ -12,3 +12,14 @@ class SaleOrder(models.Model):
         """Extend to ignore delivery lines."""
         order_lines = super().get_update_pricelist_order_lines()
         return order_lines.filtered(lambda r: not r.is_delivery)
+
+    def recompute_coupon_lines(self):
+        """Extend to trigger delivery price update."""
+        super().recompute_coupon_lines()
+        ChooseDeliveryCarrier = self.env["choose.delivery.carrier"]
+        for order in self.filtered(lambda r: r.carrier_id):
+            choose_delivery_carrier = ChooseDeliveryCarrier.create(
+                {"order_id": order.id, "carrier_id": order.carrier_id.id}
+            )
+            choose_delivery_carrier.update_price()
+            choose_delivery_carrier.button_confirm()

--- a/sale_coupon_advanced_delivery/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_advanced_delivery/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Andrius Laukavičius <andrius@focusate.eu>

--- a/sale_coupon_advanced_delivery/readme/DESCRIPTION.rst
+++ b/sale_coupon_advanced_delivery/readme/DESCRIPTION.rst
@@ -1,3 +1,3 @@
 Bridge module between Sale Coupon Advanced Programs and Delivery.
 
-Will make it to ignore delivery lines when updating order lines during promotions recomputing.
+Will make it to ignore delivery lines when updating order lines during promotions recomputing and triggers separate price update for delivery lines.

--- a/sale_coupon_advanced_delivery/readme/DESCRIPTION.rst
+++ b/sale_coupon_advanced_delivery/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+Bridge module between Sale Coupon Advanced Programs and Delivery.
+
+Will make it to ignore delivery lines when updating order lines during promotions recomputing.

--- a/sale_coupon_advanced_delivery/tests/__init__.py
+++ b/sale_coupon_advanced_delivery/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_delivery_line_price

--- a/sale_coupon_advanced_delivery/tests/test_delivery_line_price.py
+++ b/sale_coupon_advanced_delivery/tests/test_delivery_line_price.py
@@ -18,19 +18,37 @@ class TestDeliveryLinePrice(common.SavepointCase):
         cls.choose_delivery_carrier = cls.ChooseDeliveryCarrier.create(
             {"order_id": cls.sale_3.id, "carrier_id": cls.delivery_normal.id}
         )
+        cls.promotion_10_percent = cls.env.ref("sale_coupon.10_percent_auto_applied")
+
+    def _get_delivery_line_price(self, order):
+        return order.order_line.filtered("is_delivery")[0]["price_unit"]
 
     def test_01_test_delivery_line_price(self):
-        """Recompute SO to see if delivery price not reset.
+        """Recompute SO to see if delivery price is set correctly.
 
-        Case 1: add delivery line
-        Case 2: recompute promotions.
+        Case 1: add delivery line (free shipping threshold met)
+        Case 2: recompute promotions (free shipping threshold met).
         """
-        # Price must not changed, because delivery price must be 0 (
-        # SO amount is over threshold).
-        amount_total = self.sale_3.amount_total
         # Case 1.
         self.choose_delivery_carrier.button_confirm()
-        self.assertEqual(self.sale_3.amount_total, amount_total)
+        self.assertEqual(self._get_delivery_line_price(self.sale_3), 0)
         # Case 2.
         self.sale_3.recompute_coupon_lines()
-        self.assertEqual(self.sale_3.amount_total, amount_total)
+        self.assertEqual(self._get_delivery_line_price(self.sale_3), 0)
+
+    def test_02_test_delivery_line_price(self):
+        """Recompute SO to see if delivery price is set correctly.
+
+        Case 1: add delivery line (free shipping threshold met)
+        Case 2: recompute promotions (free shipping threshold not met).
+        """
+        # Case 1.
+        self.choose_delivery_carrier.button_confirm()
+        self.assertEqual(self._get_delivery_line_price(self.sale_3), 0)
+        # Case 2.
+        # To apply automatically.
+        self.promotion_10_percent.promo_code_usage = "no_code_needed"
+        # To not reach threshold after promotion is applied.
+        self.delivery_normal.amount = 350
+        self.sale_3.recompute_coupon_lines()
+        self.assertEqual(self._get_delivery_line_price(self.sale_3), 10)

--- a/sale_coupon_advanced_delivery/tests/test_delivery_line_price.py
+++ b/sale_coupon_advanced_delivery/tests/test_delivery_line_price.py
@@ -1,0 +1,36 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests import common
+
+
+class TestDeliveryLinePrice(common.SavepointCase):
+    """Test class for delivery line price extension."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up data for tests."""
+        super().setUpClass()
+        cls.ChooseDeliveryCarrier = cls.env["choose.delivery.carrier"]
+        cls.sale_3 = cls.env.ref("sale.sale_order_3")
+        cls.delivery_normal = cls.env.ref("delivery.normal_delivery_carrier")
+        # Make it free if above threshold.
+        cls.delivery_normal.write({"free_over": True, "amount": 100})
+        cls.choose_delivery_carrier = cls.ChooseDeliveryCarrier.create(
+            {"order_id": cls.sale_3.id, "carrier_id": cls.delivery_normal.id}
+        )
+
+    def test_01_test_delivery_line_price(self):
+        """Recompute SO to see if delivery price not reset.
+
+        Case 1: add delivery line
+        Case 2: recompute promotions.
+        """
+        # Price must not changed, because delivery price must be 0 (
+        # SO amount is over threshold).
+        amount_total = self.sale_3.amount_total
+        # Case 1.
+        self.choose_delivery_carrier.button_confirm()
+        self.assertEqual(self.sale_3.amount_total, amount_total)
+        # Case 2.
+        self.sale_3.recompute_coupon_lines()
+        self.assertEqual(self.sale_3.amount_total, amount_total)

--- a/setup/sale_coupon_advanced_delivery/odoo/addons/sale_coupon_advanced_delivery
+++ b/setup/sale_coupon_advanced_delivery/odoo/addons/sale_coupon_advanced_delivery
@@ -1,0 +1,1 @@
+../../../../sale_coupon_advanced_delivery

--- a/setup/sale_coupon_advanced_delivery/setup.py
+++ b/setup/sale_coupon_advanced_delivery/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Bridge module to ignore delivery lines, when updating prices, so
delivery price would not be reset every time promotions are recomputed.