### PR TITLE
[FIX] sale_coupon_advanced: forced programs

### DIFF
--- a/sale_coupon_advanced/models/sale_coupon_program.py
+++ b/sale_coupon_advanced/models/sale_coupon_program.py
@@ -4,14 +4,6 @@
 from odoo import _, api, exceptions, fields, models
 
 
-def _predicate_promo_code(program, order, coupon_code):
-    return bool(program.filtered(lambda r: r.promo_code == coupon_code))
-
-
-def _predicate_no_code_needed(program, order, coupon_code):
-    return program.promo_code_usage == "no_code_needed"
-
-
 class SaleCouponProgram(models.Model):
     _inherit = "sale.coupon.program"
 
@@ -29,7 +21,7 @@ class SaleCouponProgram(models.Model):
 
     next_n_customer_orders = fields.Integer(
         help="Maximum number of sales orders of the customer in which reward "
-             "can be provided",
+        "can be provided",
         string="Apply only on the next ",
         default=0,
     )
@@ -39,57 +31,51 @@ class SaleCouponProgram(models.Model):
         help="If checked, the reward product will be added if not ordered.",
     )
 
-    def _check_promo_code_forced(self, order, coupon_code=None, predicate=None):
-        def default_predicate(program, order, coupon_code):
-            return True
+    def _filter_programs_on_products(self, order):
+        programs = super()._filter_programs_on_products(order)
+        programs |= self.filtered(lambda r: r._is_program_forced())
+        return programs
 
-        if not predicate:
-            predicate = default_predicate
-        # Using same check again, to know which error was returned. Can't
-        # use error message, because it is unstable check. Message can
-        # be translated and it would then return different text than
-        # expected.
-        # Can also use extra predicate to further filter program.
-        return (
-            self.is_reward_product_forced
-            and self.promo_applicability == "on_current_order"
-            and self.reward_type == "product"
-            and not order._is_reward_in_order_lines(self)
-            and predicate(self, order, coupon_code)
+    def _filter_not_ordered_reward_programs(self, order):
+        programs = super()._filter_not_ordered_reward_programs(order)
+        programs_forced = self.filtered(lambda r: r._is_program_forced())
+        programs_forced_code_needed = programs_forced.filtered(
+            lambda r: r.promo_code_usage == "code_needed"
         )
+        # No code promotions must be forced only specifically when it is
+        # needed, to not duplicate promotions on each recompute.
+        if self._context.get("force_not_ordered_no_code_reward_programs"):
+            programs_forced_no_code = programs_forced.filtered(
+                lambda r: r.promo_code_usage == "no_code_needed"
+            )
+            programs |= programs_forced - programs_forced_no_code
+            # No code promotions must be added once, because no error is
+            # raised for it being used already.
+            for program_forced in programs_forced_no_code:
+                if order.order_line.filtered(
+                    lambda line: line.product_id == program_forced.reward_product_id
+                ):
+                    programs -= program_forced
+                else:
+                    programs |= program_forced
+        return programs | programs_forced_code_needed
 
     def _check_promo_code(self, order, coupon_code):
         if self.first_order_only and not order.first_order():
-            return {
-                "error":
-                    _("This code can be used only for the first sale order!")
-            }
+            return {"error": _("This code can be used only for the first sale order!")}
         order_count = self._get_order_count(order)
         max_order_number = self.next_n_customer_orders
         if max_order_number and order_count >= max_order_number:
             return {
-                "error":
-                    _("This code can be used only for the {} times!").format(
-                        max_order_number
-                    )
+                "error": _("This code can be used only for the {} times!").format(
+                    max_order_number
+                )
             }
         res = super()._check_promo_code(order, coupon_code)
-        if res.get("error") and self._check_promo_code_forced(
-            order, coupon_code=coupon_code, predicate=_predicate_promo_code
-        ):
-            return {}
         return res
 
     @api.model
     def _filter_programs_from_common_rules(self, order, next_order=False):
-        # FIXME: this is not great, because this method responsibility
-        # is to just filter programs, not silently create lines.
-        for program in self:
-            order._filter_force_create_counter_line_for_reward_product(
-                program,
-                # This call is only meant for auto applied promotions.
-                predicate=_predicate_no_code_needed,
-            )
         programs = super()._filter_programs_from_common_rules(order, next_order)
         programs = programs._filter_first_order_programs(order)
         programs = programs._filter_order_programs(
@@ -152,6 +138,16 @@ class SaleCouponProgram(models.Model):
                 continue
             filtered_programs |= program
         return filtered_programs
+
+    def _is_program_forced(self):
+        self.ensure_one()
+        return (
+            self.is_reward_product_forced
+            # Extra checks to make sure it is only applied for promotion
+            # product rewards.
+            and self.program_type == "promotion_program"
+            and self.reward_type == "product"
+        )
 
 
 class SaleCouponReward(models.Model):

--- a/sale_coupon_advanced/models/sale_order.py
+++ b/sale_coupon_advanced/models/sale_order.py
@@ -89,10 +89,11 @@ class SaleOrder(models.Model):
         for program in programs.filtered(lambda r: r._is_program_forced()):
             self._create_counter_line_for_reward_product(program)
         super()._create_new_no_code_promo_reward_lines()
-        # Can there be only one such pricelist program?
         program_pricelist = programs.filtered(
             lambda r: r.reward_type == "use_pricelist"
-        )
+        )[
+            :1
+        ]  # making sure we limit to 1.
         if (
             program_pricelist
             and self.pricelist_id != program_pricelist.reward_pricelist_id

--- a/sale_coupon_advanced/models/sale_order.py
+++ b/sale_coupon_advanced/models/sale_order.py
@@ -6,6 +6,11 @@ from odoo import _, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    def _is_reward_in_order_lines(self, program):
+        if program._is_program_forced():
+            return True  # forced program ignores this check.
+        return super()._is_reward_in_order_lines(program)
+
     def _get_next_order_line_sequence(self):
         self.ensure_one()
         seq = 1
@@ -18,18 +23,9 @@ class SaleOrder(models.Model):
             return seq
 
     def _create_reward_line(self, program):
-        self._filter_force_create_counter_line_for_reward_product(program)
-        super()._create_reward_line(program)
-
-    def _filter_force_create_counter_line_for_reward_product(
-        self, program, predicate=None
-    ):
-        """Create counter line if its needed for program."""
-        # NOTE. Not passing coupon_code, because from this call we dont
-        # have it, but its not needed either (so will just default to
-        # None).
-        if program._check_promo_code_forced(self, predicate=predicate):
+        if program._is_program_forced():
             self._create_counter_line_for_reward_product(program)
+        super()._create_reward_line(program)
 
     def _create_counter_line_for_reward_product(self, program):
         """Create force line to counter balance discount line.
@@ -60,6 +56,7 @@ class SaleOrder(models.Model):
                 "order_id": self.id,
             }
         )
+        # TODO: is this still necessary?
         sol.product_id_change()
         return sol
 
@@ -86,12 +83,21 @@ class SaleOrder(models.Model):
         return programs
 
     def _create_new_no_code_promo_reward_lines(self):
+        programs = self.with_context(
+            force_not_ordered_no_code_reward_programs=True
+        )._get_applicable_no_code_promo_program()
+        for program in programs.filtered(lambda r: r._is_program_forced()):
+            self._create_counter_line_for_reward_product(program)
         super()._create_new_no_code_promo_reward_lines()
-        program = self._get_applicable_no_code_promo_program().filtered(
-            lambda p: p.reward_type == "use_pricelist"
+        # Can there be only one such pricelist program?
+        program_pricelist = programs.filtered(
+            lambda r: r.reward_type == "use_pricelist"
         )
-        if program and self.pricelist_id != program.reward_pricelist_id:
-            self._update_pricelist(program.reward_pricelist_id)
+        if (
+            program_pricelist
+            and self.pricelist_id != program_pricelist.reward_pricelist_id
+        ):
+            self._update_pricelist(program_pricelist.reward_pricelist_id)
 
     def _get_reward_line_values(self, program):
         # due to convention reward line should be created, in case of pricelist


### PR DESCRIPTION
Redesigned and simplified forced programs (for product reward)
implementation. Now counter line for no code promotion reward is created
logically inside _create_new_no_code_promo_reward_lines instead of
during filtering -> which caused various problems, like duplicating
rewards (because filtering is called multiple times).

Also simplified the way forced program promotions are checked whether
they are valid. Before it was checking incorrectly, because it would
bypass many checks which it should have not.
Now only relevant checks are extended to allow it to be bypassed, but
other checks are triggered unaffected.