### PR TITLE
[FIX] sale_coupon_product_management: list_price

### DIFF
--- a/sale_coupon_product_management/tests/test_sale_coupon_manage.py
+++ b/sale_coupon_product_management/tests/test_sale_coupon_manage.py
@@ -54,11 +54,10 @@ class TestSaleCouponManage(TestSaleCouponProductManageCommon):
     def test_02_program_discount_product_rel_vals(self):
         """Check if option values are passed to product.
 
-        Case: passing sale_ok.
+        Case: on program create - passing sale_ok, list_price.
         """
-        self.product_category_coupon.program_option_ids = [
-            (6, 0, self.program_option_sale_ok.ids)
-        ]
+        options = self.program_option_sale_ok | self.program_option_fixed_amount
+        self.product_category_coupon.program_option_ids = [(6, 0, options.ids)]
         program = self.SaleCouponProgram.create(
             {
                 "name": "Coupon Program 2",
@@ -72,6 +71,7 @@ class TestSaleCouponManage(TestSaleCouponProductManageCommon):
         )
         product = program.discount_line_product_id
         self.assertTrue(product.sale_ok)
+        self.assertEqual(product.list_price, 1000)
 
     def test_03_check_program_options(self):
         """Validate if program values match its related options.


### PR DESCRIPTION
get_program_values can use direct values from `program` now, but related
program was not passed (on program create) to take those value.

Also merged extra_product_vals with forced_product_vals to pass values
once, instead of needlessly calling write later.